### PR TITLE
Speed up ROCmFPX FP3 Vulkan path

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -7065,6 +7065,7 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec(ggml_backend_vk_context * 
             case GGML_TYPE_MXFP4:
             case GGML_TYPE_Q4_0_ROCMFP4:
             case GGML_TYPE_Q4_0_ROCMFP4_FAST:
+            case GGML_TYPE_Q3_0_ROCMFPX:
             case GGML_TYPE_Q2_K:
             case GGML_TYPE_Q3_K:
             case GGML_TYPE_Q4_K:
@@ -7239,6 +7240,7 @@ static vk_pipeline ggml_vk_get_dequantize_mul_mat_vec_id(ggml_backend_vk_context
             case GGML_TYPE_MXFP4:
             case GGML_TYPE_Q4_0_ROCMFP4:
             case GGML_TYPE_Q4_0_ROCMFP4_FAST:
+            case GGML_TYPE_Q3_0_ROCMFPX:
             case GGML_TYPE_Q2_K:
             case GGML_TYPE_Q3_K:
             case GGML_TYPE_Q4_K:
@@ -16792,6 +16794,7 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                     case GGML_TYPE_Q4_0:
                     case GGML_TYPE_Q4_0_ROCMFP4:
                     case GGML_TYPE_Q4_0_ROCMFP4_FAST:
+                    case GGML_TYPE_Q3_0_ROCMFPX:
                     case GGML_TYPE_IQ4_NL:
                     case GGML_TYPE_Q1_0:
                         return true;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
@@ -538,14 +538,36 @@ uint rocmfpx_fp3_get_bits(uint ib, uint bit_pos, uint a_offset) {
 }
 
 int rocmfpx_fp3_decode_code(uint code) {
-    const uint mag_code = code & 3u;
-    const int mag = mag_code == 3u ? 4 : int(mag_code);
-    return (code & 4u) != 0u ? -mag : mag;
+    return int(kvalues_rocmfpx_fp3_const[code & 7u]);
 }
 
 float rocmfpx_fp3_dequant(uint ib, uint idx, uint a_offset) {
     const float d = ue4m3_to_fp32(data_a[a_offset + ib].e[idx >= 16u ? 1u : 0u]);
     return float(rocmfpx_fp3_decode_code(rocmfpx_fp3_get_bits(ib, idx * 3u, a_offset))) * d;
+}
+
+int32_t rocmfpx_fp3_pack4_window(uint ib, uint idx, uint a_offset) {
+    const uint bit_pos = idx * 3u;
+    const uint byte_pos = bit_pos >> 3u;
+    const uint sh = bit_pos & 7u;
+    uint bits = uint(data_a[a_offset + ib].qs[byte_pos]) |
+                (uint(data_a[a_offset + ib].qs[byte_pos + 1u]) << 8);
+    if (sh > 4u) {
+        bits |= uint(data_a[a_offset + ib].qs[byte_pos + 2u]) << 16;
+    }
+    bits = (bits >> sh) & 0xFFFu;
+    return pack32(i8vec4(kvalues_rocmfpx_fp3_const[ bits        & 7u],
+                         kvalues_rocmfpx_fp3_const[(bits >> 3) & 7u],
+                         kvalues_rocmfpx_fp3_const[(bits >> 6) & 7u],
+                         kvalues_rocmfpx_fp3_const[(bits >> 9) & 7u]));
+}
+
+vec4 rocmfpx_fp3_dequant4(uint ib, uint idx, uint a_offset) {
+    const vec4 q = vec4(unpack8(rocmfpx_fp3_pack4_window(ib, idx, a_offset)));
+    return q * vec4(ue4m3_to_fp32(data_a[a_offset + ib].e[(idx + 0u) >= 16u ? 1u : 0u]),
+                    ue4m3_to_fp32(data_a[a_offset + ib].e[(idx + 1u) >= 16u ? 1u : 0u]),
+                    ue4m3_to_fp32(data_a[a_offset + ib].e[(idx + 2u) >= 16u ? 1u : 0u]),
+                    ue4m3_to_fp32(data_a[a_offset + ib].e[(idx + 3u) >= 16u ? 1u : 0u]));
 }
 
 vec2 dequantize(uint ib, uint iqs, uint a_offset) {
@@ -554,10 +576,7 @@ vec2 dequantize(uint ib, uint iqs, uint a_offset) {
 }
 
 vec4 dequantize4(uint ib, uint iqs, uint a_offset) {
-    return vec4(rocmfpx_fp3_dequant(ib, iqs + 0u, a_offset),
-                rocmfpx_fp3_dequant(ib, iqs + 1u, a_offset),
-                rocmfpx_fp3_dequant(ib, iqs + 2u, a_offset),
-                rocmfpx_fp3_dequant(ib, iqs + 3u, a_offset));
+    return rocmfpx_fp3_dequant4(ib, iqs, a_offset);
 }
 #endif
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs_cm2.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs_cm2.glsl
@@ -1357,9 +1357,7 @@ uint rocmfpx_cm2_fp3_get_bits(const in decodeBufROCMFPXFP3 bl, uint bit_pos)
 
 int rocmfpx_cm2_fp3_decode(uint code)
 {
-    const uint mag_code = code & 3u;
-    const int mag = mag_code == 3u ? 4 : int(mag_code);
-    return (code & 4u) != 0u ? -mag : mag;
+    return int(kvalues_rocmfpx_fp3_const[code & 7u]);
 }
 
 float16_t dequantFuncROCMFPXFP3(const in decodeBufROCMFPXFP3 bl, const in uint blockCoords[2], const in uint coordInBlock[2])
@@ -1369,13 +1367,31 @@ float16_t dequantFuncROCMFPXFP3(const in decodeBufROCMFPXFP3 bl, const in uint b
     return float16_t(float(rocmfpx_cm2_fp3_decode(rocmfpx_cm2_fp3_get_bits(bl, idx * 3u))) * d);
 }
 
+int32_t rocmfpx_cm2_fp3_pack4_window(const in decodeBufROCMFPXFP3 bl, uint idx)
+{
+    const uint bit_pos = idx * 3u;
+    const uint byte_pos = bit_pos >> 3u;
+    const uint sh = bit_pos & 7u;
+    uint bits = uint(bl.block.qs[byte_pos]) |
+                (uint(bl.block.qs[byte_pos + 1u]) << 8);
+    if (sh > 4u) {
+        bits |= uint(bl.block.qs[byte_pos + 2u]) << 16;
+    }
+    bits = (bits >> sh) & 0xFFFu;
+    return pack32(i8vec4(kvalues_rocmfpx_fp3_const[ bits        & 7u],
+                         kvalues_rocmfpx_fp3_const[(bits >> 3) & 7u],
+                         kvalues_rocmfpx_fp3_const[(bits >> 6) & 7u],
+                         kvalues_rocmfpx_fp3_const[(bits >> 9) & 7u]));
+}
+
 f16vec4 dequantFuncROCMFPXFP3_v(const in decodeBufROCMFPXFP3 bl, const in uint blockCoords[2], const in uint coordInBlock[2])
 {
     const uint idx = coordInBlock[1];
-    return f16vec4(float16_t(float(rocmfpx_cm2_fp3_decode(rocmfpx_cm2_fp3_get_bits(bl, (idx + 0u) * 3u))) * ue4m3_to_fp32(bl.block.e[(idx + 0u) >= 16u ? 1u : 0u])),
-                   float16_t(float(rocmfpx_cm2_fp3_decode(rocmfpx_cm2_fp3_get_bits(bl, (idx + 1u) * 3u))) * ue4m3_to_fp32(bl.block.e[(idx + 1u) >= 16u ? 1u : 0u])),
-                   float16_t(float(rocmfpx_cm2_fp3_decode(rocmfpx_cm2_fp3_get_bits(bl, (idx + 2u) * 3u))) * ue4m3_to_fp32(bl.block.e[(idx + 2u) >= 16u ? 1u : 0u])),
-                   float16_t(float(rocmfpx_cm2_fp3_decode(rocmfpx_cm2_fp3_get_bits(bl, (idx + 3u) * 3u))) * ue4m3_to_fp32(bl.block.e[(idx + 3u) >= 16u ? 1u : 0u])));
+    const vec4 q = vec4(unpack8(rocmfpx_cm2_fp3_pack4_window(bl, idx)));
+    return f16vec4(q * vec4(ue4m3_to_fp32(bl.block.e[(idx + 0u) >= 16u ? 1u : 0u]),
+                            ue4m3_to_fp32(bl.block.e[(idx + 1u) >= 16u ? 1u : 0u]),
+                            ue4m3_to_fp32(bl.block.e[(idx + 2u) >= 16u ? 1u : 0u]),
+                            ue4m3_to_fp32(bl.block.e[(idx + 3u) >= 16u ? 1u : 0u])));
 }
 #endif
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vecq.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vecq.comp
@@ -5,17 +5,21 @@
 
 #define MMQ
 #define NEEDS_IQ1S_GRID_GPU
+#if defined(DATA_A_ROCMFPX_FP3)
+#define B_TYPE block_q8_1_x4_packed128
+#else
 #define B_TYPE block_q8_1_x4
+#endif
 
 #include "mul_mat_vec_base.glsl"
 
 layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
 
-#if defined(DATA_A_QUANT_LEGACY) || defined(DATA_A_MXFP4) || defined(DATA_A_ROCMFP4) || defined(DATA_A_ROCMFP4_FAST) || defined(DATA_A_ROCMFPX_FAMILY)
+#if defined(DATA_A_QUANT_LEGACY) || defined(DATA_A_MXFP4) || defined(DATA_A_ROCMFP4) || defined(DATA_A_ROCMFP4_FAST) || defined(DATA_A_ROCMFPX_FP6) || defined(DATA_A_ROCMFPX_FP8)
 #define K_PER_ITER 8
 #elif defined(DATA_A_QUANT_K)
 #define K_PER_ITER 16
-#elif defined(DATA_A_IQ1_S) || defined(DATA_A_IQ1_M)
+#elif defined(DATA_A_IQ1_S) || defined(DATA_A_IQ1_M) || defined(DATA_A_ROCMFPX_FP3)
 #define K_PER_ITER 32
 #else
 #error unimplemented
@@ -23,7 +27,12 @@ layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
 
 uint a_offset, b_offset, d_offset;
 
+#if defined(DATA_A_ROCMFPX_FP3)
+ivec4 cache_b_qs0;
+ivec4 cache_b_qs1;
+#else
 int32_t cache_b_qs[K_PER_ITER / 4];
+#endif
 vec2 cache_b_ds;
 
 #include "mul_mat_vecq_funcs.glsl"
@@ -53,6 +62,10 @@ void iter(inout FLOAT_TYPE temp[NUM_COLS][NUM_ROWS], const uint first_row, const
         cache_b_qs[2] = data_b[b_block_idx_outer].qs[b_block_idx_inner * 8 + b_qs_idx * 4 + 2];
         cache_b_qs[3] = data_b[b_block_idx_outer].qs[b_block_idx_inner * 8 + b_qs_idx * 4 + 3];
 #elif K_PER_ITER == 32
+#if defined(DATA_A_ROCMFPX_FP3)
+        cache_b_qs0 = data_b[b_block_idx_outer].qs[b_block_idx_inner * 2    ];
+        cache_b_qs1 = data_b[b_block_idx_outer].qs[b_block_idx_inner * 2 + 1];
+#else
         cache_b_qs[0] = data_b[b_block_idx_outer].qs[b_block_idx_inner * 8    ];
         cache_b_qs[1] = data_b[b_block_idx_outer].qs[b_block_idx_inner * 8 + 1];
         cache_b_qs[2] = data_b[b_block_idx_outer].qs[b_block_idx_inner * 8 + 2];
@@ -61,6 +74,7 @@ void iter(inout FLOAT_TYPE temp[NUM_COLS][NUM_ROWS], const uint first_row, const
         cache_b_qs[5] = data_b[b_block_idx_outer].qs[b_block_idx_inner * 8 + 5];
         cache_b_qs[6] = data_b[b_block_idx_outer].qs[b_block_idx_inner * 8 + 6];
         cache_b_qs[7] = data_b[b_block_idx_outer].qs[b_block_idx_inner * 8 + 7];
+#endif
 #else
 #error unimplemented
 #endif
@@ -95,7 +109,11 @@ void compute_outputs(const uint32_t first_row, const uint32_t num_rows) {
     if (num_iters * K_PER_ITER * BLOCK_SIZE + K_PER_ITER*tid < p.ncols) {
         num_iters++;
     }
+#if defined(DATA_A_ROCMFPX_FP3)
+    int unroll_count = 1;
+#else
     int unroll_count = 4;
+#endif
     uint unrolled_iters = num_iters & ~(unroll_count - 1);
 
     uint i = 0;

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vecq.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vecq.comp
@@ -110,10 +110,13 @@ void compute_outputs(const uint32_t first_row, const uint32_t num_rows) {
         num_iters++;
     }
 #if defined(DATA_A_ROCMFPX_FP3)
-    int unroll_count = 1;
+    uint i = 0;
+    while (i < num_iters) {
+        iter(temp, first_row, num_rows, tid, i*K_PER_ITER);
+        i++;
+    }
 #else
     int unroll_count = 4;
-#endif
     uint unrolled_iters = num_iters & ~(unroll_count - 1);
 
     uint i = 0;
@@ -139,6 +142,7 @@ void compute_outputs(const uint32_t first_row, const uint32_t num_rows) {
         iter(temp, first_row, num_rows, tid, i*K_PER_ITER);
         i++;
     }
+#endif
 
     reduce_result(temp, d_offset, first_row, num_rows, tid);
 }

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vecq_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vecq_funcs.glsl
@@ -183,21 +183,20 @@ uint rocmfpx_vq_fp3_get_bits(uint ib, uint bit_pos) {
 }
 
 int rocmfpx_vq_fp3_decode(uint code) {
-    return int(kvalues_rocmfpx_fp3_const[code & 7u]);
+    const uint mag = code & 3u;
+    const int value = int(mag + ((mag >> 1u) & (mag & 1u)));
+    return (code & 4u) != 0u ? -value : value;
 }
 
-int32_t rocmfpx_vq_fp3_pack4(uint ib, uint group) {
+int32_t rocmfpx_vq_fp3_pack4(uint qs0, uint qs1, uint qs2, uint group) {
     const uint start_bit = 12u * group;
     const uint reg_shift = start_bit & 31u;
     const uint reg_idx = start_bit >> 5;
-    const uint qs0 = pack32(u8vec4(data_a[ib].qs[0], data_a[ib].qs[1], data_a[ib].qs[2], data_a[ib].qs[3]));
-    const uint qs1 = pack32(u8vec4(data_a[ib].qs[4], data_a[ib].qs[5], data_a[ib].qs[6], data_a[ib].qs[7]));
-    const uint qs2 = pack32(u8vec4(data_a[ib].qs[8], data_a[ib].qs[9], data_a[ib].qs[10], data_a[ib].qs[11]));
     const uint val_low  = reg_idx == 0u ? qs0 : (reg_idx == 1u ? qs1 : qs2);
     const uint val_high = reg_idx == 0u ? qs1 : (reg_idx == 1u ? qs2 : 0u);
     const uint bits12 = reg_shift == 0u ?
-        (val_low & 0xFFFu) :
-        (((val_low >> reg_shift) | (val_high << (32u - reg_shift))) & 0xFFFu);
+        val_low :
+        ((val_low >> reg_shift) | (val_high << (32u - reg_shift)));
     return pack32(i8vec4(int8_t(rocmfpx_vq_fp3_decode(bits12 & 7u)),
                          int8_t(rocmfpx_vq_fp3_decode((bits12 >> 3) & 7u)),
                          int8_t(rocmfpx_vq_fp3_decode((bits12 >> 6) & 7u)),
@@ -205,22 +204,22 @@ int32_t rocmfpx_vq_fp3_pack4(uint ib, uint group) {
 }
 
 FLOAT_TYPE mmvq_dot_product(const uint ib_a, const uint iqs) {
-    int32_t sumi0 = 0;
-    int32_t sumi1 = 0;
-    [[unroll]] for (uint lane = 0u; lane < 2u; ++lane) {
-        const uint group = 2u * iqs + lane;
-        const int32_t v = rocmfpx_vq_fp3_pack4(ib_a, group);
-        const uint base = 4u * group;
-        const int32_t u = cache_b_qs[lane];
-        if (base < QUANT_K / 2u) {
-            sumi0 += dotPacked4x8EXT(v, u);
-        } else {
-            sumi1 += dotPacked4x8EXT(v, u);
-        }
-    }
+    const uint qs0 = pack32(u8vec4(data_a[ib_a].qs[0], data_a[ib_a].qs[1], data_a[ib_a].qs[2], data_a[ib_a].qs[3]));
+    const uint qs1 = pack32(u8vec4(data_a[ib_a].qs[4], data_a[ib_a].qs[5], data_a[ib_a].qs[6], data_a[ib_a].qs[7]));
+    const uint qs2 = pack32(u8vec4(data_a[ib_a].qs[8], data_a[ib_a].qs[9], data_a[ib_a].qs[10], data_a[ib_a].qs[11]));
+
+    const int32_t q_sum0 = dotPacked4x8EXT(rocmfpx_vq_fp3_pack4(qs0, qs1, qs2, 0u), cache_b_qs0.x) +
+                           dotPacked4x8EXT(rocmfpx_vq_fp3_pack4(qs0, qs1, qs2, 1u), cache_b_qs0.y) +
+                           dotPacked4x8EXT(rocmfpx_vq_fp3_pack4(qs0, qs1, qs2, 2u), cache_b_qs0.z) +
+                           dotPacked4x8EXT(rocmfpx_vq_fp3_pack4(qs0, qs1, qs2, 3u), cache_b_qs0.w);
+    const int32_t q_sum1 = dotPacked4x8EXT(rocmfpx_vq_fp3_pack4(qs0, qs1, qs2, 4u), cache_b_qs1.x) +
+                           dotPacked4x8EXT(rocmfpx_vq_fp3_pack4(qs0, qs1, qs2, 5u), cache_b_qs1.y) +
+                           dotPacked4x8EXT(rocmfpx_vq_fp3_pack4(qs0, qs1, qs2, 6u), cache_b_qs1.z) +
+                           dotPacked4x8EXT(rocmfpx_vq_fp3_pack4(qs0, qs1, qs2, 7u), cache_b_qs1.w);
+
     const FLOAT_TYPE d0 = FLOAT_TYPE(ue4m3_to_fp32(data_a[ib_a].e[0]));
     const FLOAT_TYPE d1 = FLOAT_TYPE(ue4m3_to_fp32(data_a[ib_a].e[1]));
-    return FLOAT_TYPE(cache_b_ds.x * (d0 * float(sumi0) + d1 * float(sumi1)));
+    return FLOAT_TYPE(cache_b_ds.x * (d0 * float(q_sum0) + d1 * float(q_sum1)));
 }
 #endif
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vecq_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vecq_funcs.glsl
@@ -183,13 +183,11 @@ uint rocmfpx_vq_fp3_get_bits(uint ib, uint bit_pos) {
 }
 
 int rocmfpx_vq_fp3_decode(uint code) {
-    const uint mag_code = code & 3u;
-    const int mag = mag_code == 3u ? 4 : int(mag_code);
-    return (code & 4u) != 0u ? -mag : mag;
+    return int(kvalues_rocmfpx_fp3_const[code & 7u]);
 }
 
-int32_t rocmfpx_vq_fp3_pack4(uint ib, uint iqs, uint lane) {
-    const uint start_bit = 12u * (iqs + lane);
+int32_t rocmfpx_vq_fp3_pack4(uint ib, uint group) {
+    const uint start_bit = 12u * group;
     const uint reg_shift = start_bit & 31u;
     const uint reg_idx = start_bit >> 5;
     const uint qs0 = pack32(u8vec4(data_a[ib].qs[0], data_a[ib].qs[1], data_a[ib].qs[2], data_a[ib].qs[3]));
@@ -197,7 +195,9 @@ int32_t rocmfpx_vq_fp3_pack4(uint ib, uint iqs, uint lane) {
     const uint qs2 = pack32(u8vec4(data_a[ib].qs[8], data_a[ib].qs[9], data_a[ib].qs[10], data_a[ib].qs[11]));
     const uint val_low  = reg_idx == 0u ? qs0 : (reg_idx == 1u ? qs1 : qs2);
     const uint val_high = reg_idx == 0u ? qs1 : (reg_idx == 1u ? qs2 : 0u);
-    const uint bits12 = ((val_low >> reg_shift) | (val_high << (32u - reg_shift))) & 0xFFFu;
+    const uint bits12 = reg_shift == 0u ?
+        (val_low & 0xFFFu) :
+        (((val_low >> reg_shift) | (val_high << (32u - reg_shift))) & 0xFFFu);
     return pack32(i8vec4(int8_t(rocmfpx_vq_fp3_decode(bits12 & 7u)),
                          int8_t(rocmfpx_vq_fp3_decode((bits12 >> 3) & 7u)),
                          int8_t(rocmfpx_vq_fp3_decode((bits12 >> 6) & 7u)),
@@ -208,13 +208,14 @@ FLOAT_TYPE mmvq_dot_product(const uint ib_a, const uint iqs) {
     int32_t sumi0 = 0;
     int32_t sumi1 = 0;
     [[unroll]] for (uint lane = 0u; lane < 2u; ++lane) {
-        const int32_t v = rocmfpx_vq_fp3_pack4(ib_a, iqs, lane);
-        const uint base = 4u * (iqs + lane);
+        const uint group = 2u * iqs + lane;
+        const int32_t v = rocmfpx_vq_fp3_pack4(ib_a, group);
+        const uint base = 4u * group;
         const int32_t u = cache_b_qs[lane];
         if (base < QUANT_K / 2u) {
-            sumi0 = dotPacked4x8EXT(v, u);
+            sumi0 += dotPacked4x8EXT(v, u);
         } else {
-            sumi1 = dotPacked4x8EXT(v, u);
+            sumi1 += dotPacked4x8EXT(v, u);
         }
     }
     const FLOAT_TYPE d0 = FLOAT_TYPE(ue4m3_to_fp32(data_a[ib_a].e[0]));

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mm_funcs.glsl
@@ -1,29 +1,23 @@
 #if defined(DATA_A_ROCMFPX_FP3)
-uint rocmfpx_mm_fp3_get_bits(uint ib, uint bit_pos) {
-    uint code = 0u;
-    [[unroll]] for (uint bit = 0u; bit < 3u; ++bit) {
-        const uint src_bit = bit_pos + bit;
-        code |= ((uint(data_a[ib].qs[src_bit >> 3u]) >> (src_bit & 7u)) & 1u) << bit;
+int32_t rocmfpx_mm_fp3_pack4_window(uint ib, uint idx) {
+    const uint bit_pos = idx * 3u;
+    const uint byte_pos = bit_pos >> 3u;
+    const uint sh = bit_pos & 7u;
+    uint bits = uint(data_a[ib].qs[byte_pos]) |
+                (uint(data_a[ib].qs[byte_pos + 1u]) << 8);
+    if (sh > 4u) {
+        bits |= uint(data_a[ib].qs[byte_pos + 2u]) << 16;
     }
-    return code;
-}
-
-int rocmfpx_mm_fp3_decode(uint code) {
-    const uint mag_code = code & 3u;
-    const int mag = mag_code == 3u ? 4 : int(mag_code);
-    return (code & 4u) != 0u ? -mag : mag;
-}
-
-float rocmfpx_mm_fp3_value(uint ib, uint idx) {
-    const float d = ue4m3_to_fp32(data_a[ib].e[idx >= 16u ? 1u : 0u]);
-    return float(rocmfpx_mm_fp3_decode(rocmfpx_mm_fp3_get_bits(ib, idx * 3u))) * d;
+    bits = (bits >> sh) & 0xFFFu;
+    return pack32(i8vec4(kvalues_rocmfpx_fp3_const[ bits        & 7u],
+                         kvalues_rocmfpx_fp3_const[(bits >> 3) & 7u],
+                         kvalues_rocmfpx_fp3_const[(bits >> 6) & 7u],
+                         kvalues_rocmfpx_fp3_const[(bits >> 9) & 7u]));
 }
 
 vec4 rocmfpx_mm_fp3_vec4(uint ib, uint idx) {
-    return vec4(rocmfpx_mm_fp3_value(ib, idx + 0u),
-                rocmfpx_mm_fp3_value(ib, idx + 1u),
-                rocmfpx_mm_fp3_value(ib, idx + 2u),
-                rocmfpx_mm_fp3_value(ib, idx + 3u));
+    const float d = ue4m3_to_fp32(data_a[ib].e[idx >= 16u ? 1u : 0u]);
+    return vec4(unpack8(rocmfpx_mm_fp3_pack4_window(ib, idx))) * d;
 }
 #endif
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/types.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/types.glsl
@@ -1975,6 +1975,11 @@ float ue4m3_to_fp32(uint8_t x) {
 #endif
 
 #if defined(DATA_A_ROCMFPX_FAMILY)
+const int8_t kvalues_rocmfpx_fp3_const[8] = {
+    int8_t(0), int8_t(1), int8_t(2), int8_t(4),
+    int8_t(0), int8_t(-1), int8_t(-2), int8_t(-4)
+};
+
 const int8_t kvalues_rocmfpx_fp6_const[64] = {
     int8_t(0), int8_t(1), int8_t(2), int8_t(3), int8_t(4), int8_t(5), int8_t(6), int8_t(7),
     int8_t(8), int8_t(9), int8_t(10), int8_t(11), int8_t(12), int8_t(13), int8_t(14), int8_t(15),


### PR DESCRIPTION
## Summary

This tightens the Vulkan path for `Q3_0_ROCMFPX` / FP3 only:

- allows `Q3_0_ROCMFPX` through the existing Vulkan quantized matvec fast path
- fixes FP3 matvec group indexing so lanes cover the correct half-block sums
- moves FP3 matvec to `K_PER_ITER = 32`
- replaces scalar bit-by-bit FP3 decode with packed 4-value window decodes and arithmetic FP3 code decode
- uses an FP3-only packed Q8_1 B-side view cached as two `ivec4`s
- specializes the FP3 matvec outer loop to avoid the generic 4/2 unroll scaffold in the heavier K32 shader

I intentionally left the Q6/FP6 experiments out of this PR because they need separate work: local testing showed prompt-throughput wins but decode regressions.

## Validation

Built a fresh Vulkan `llama-bench` from this branch on Strix Halo / RADV:

```bash
cmake -S . -B build-vulkan-nocheck -DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=ON -G Ninja
cmake --build build-vulkan-nocheck --target llama-bench -j $(nproc)
```

Benchmark flags:

```bash
-ngl 999 -fa on -ctk f16 -ctv f16 -b 2048 -ub 512 -t 16 -p 2048 -n 128 -r 5 --delay 1 -o jsonl
```

Hardware/backend:

```text
AMD Radeon 8060S Graphics (RADV STRIX_HALO), Vulkan int dot enabled
```

Models:

```text
ROCmFP3: Qwen3.6-35B-A3B-MTP-BF16-to-Q3_0_ROCMFPX-PURE.gguf
Q3_K_S:  Qwen3.6-35B-A3B-MTP-BF16-to-Q3_K_S.gguf
```

Results:

| run | prompt throughput | decode throughput |
| --- | ---: | ---: |
| FP3 prepatch avg, 2x r=5 | 1003.59 tok/s | 56.63 tok/s |
| earlier PR state, r=5 | 1150.69 tok/s | 67.72 tok/s |
| final FP3, `6de71ff`, r=5 | 1154.17 tok/s | 85.30 tok/s |
| final Q3_K_S, `6de71ff`, r=5 | 979.17 tok/s | 83.71 tok/s |

Decode deltas from the final `6de71ff` rows:

- final FP3 vs prepatch FP3: about `+50.6%`
- final FP3 vs earlier PR state: about `+26.0%`
- final FP3 vs final same-build Q3_K_S: about `+1.90%`