### PR TITLE
Vulkan: optimize ROCmFPX FP6 decode for Q6 matvec

### DIFF
--- a/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
@@ -595,9 +595,36 @@ int rocmfpx_fp6_decode_code(uint code) {
     return (code & 32u) != 0u ? -mag : mag;
 }
 
+float rocmfpx_fp6_decode_code_f32(uint code) {
+    const int sign = -int(code >> 5);
+    return float((int(code & 31u) ^ sign) - sign);
+}
+
 float rocmfpx_fp6_dequant(uint ib, uint idx, uint a_offset) {
     const float d = ue4m3_to_fp32(data_a[a_offset + ib].e[idx >= 16u ? 1u : 0u]);
     return float(rocmfpx_fp6_decode_code(rocmfpx_fp6_get_bits(ib, idx * 6u, a_offset))) * d;
+}
+
+vec4 rocmfpx_fp6_dequant4_aligned(uint ib, uint idx, uint a_offset) {
+    const uint qib = a_offset + ib;
+    const uint byte_pos = 3u * (idx >> 2);
+    const uint bits = uint(data_a[qib].qs[byte_pos + 0u]) |
+                     (uint(data_a[qib].qs[byte_pos + 1u]) <<  8) |
+                     (uint(data_a[qib].qs[byte_pos + 2u]) << 16);
+    const float d = ue4m3_to_fp32(data_a[qib].e[idx >= 16u ? 1u : 0u]);
+    return d * vec4(rocmfpx_fp6_decode_code_f32( bits        & 0x3Fu),
+                    rocmfpx_fp6_decode_code_f32((bits >>  6) & 0x3Fu),
+                    rocmfpx_fp6_decode_code_f32((bits >> 12) & 0x3Fu),
+                    rocmfpx_fp6_decode_code_f32((bits >> 18) & 0x3Fu));
+}
+
+vec4 rocmfpx_fp6_dequant4(uint ib, uint idx, uint a_offset) {
+    const uint qib = a_offset + ib;
+    const vec4 q = vec4(unpack8(rocmfpx_fp6_pack4_window_qs(data_a[qib].qs, idx)));
+    return q * vec4(ue4m3_to_fp32(data_a[qib].e[(idx + 0u) >= 16u ? 1u : 0u]),
+                    ue4m3_to_fp32(data_a[qib].e[(idx + 1u) >= 16u ? 1u : 0u]),
+                    ue4m3_to_fp32(data_a[qib].e[(idx + 2u) >= 16u ? 1u : 0u]),
+                    ue4m3_to_fp32(data_a[qib].e[(idx + 3u) >= 16u ? 1u : 0u]));
 }
 
 vec2 dequantize(uint ib, uint iqs, uint a_offset) {
@@ -606,10 +633,7 @@ vec2 dequantize(uint ib, uint iqs, uint a_offset) {
 }
 
 vec4 dequantize4(uint ib, uint iqs, uint a_offset) {
-    return vec4(rocmfpx_fp6_dequant(ib, iqs + 0u, a_offset),
-                rocmfpx_fp6_dequant(ib, iqs + 1u, a_offset),
-                rocmfpx_fp6_dequant(ib, iqs + 2u, a_offset),
-                rocmfpx_fp6_dequant(ib, iqs + 3u, a_offset));
+    return rocmfpx_fp6_dequant4(ib, iqs, a_offset);
 }
 #endif
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec.comp
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vec.comp
@@ -74,6 +74,12 @@ void iter(inout FLOAT_TYPE temp[NUM_COLS][NUM_ROWS], const uint first_row, const
             ibi += p.ncols;
 
 #if K_PER_ITER == 8
+#if defined(DATA_A_ROCMFPX_FP6)
+            const vec4 v = rocmfpx_fp6_dequant4_aligned(ib, iqs, a_offset);
+            const vec4 v2 = rocmfpx_fp6_dequant4_aligned(ib, iqs + 4u, a_offset);
+
+            temp[j][n] += dot(bv0, v) + dot(bv1, v2);
+#else
             vec4 v = dequantize4(ib, iqs, a_offset);
             vec4 v2 = dequantize4(ib, iqs+(4/QUANT_R), a_offset);
 
@@ -91,6 +97,7 @@ void iter(inout FLOAT_TYPE temp[NUM_COLS][NUM_ROWS], const uint first_row, const
                 rowtmp *= dm.x;
 
             temp[j][n] += rowtmp;
+#endif
 #else
             if (!OOB_w) {
                 const vec4 v = dequantize4(ib, iqs, a_offset);

--- a/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vecq_funcs.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/mul_mat_vecq_funcs.glsl
@@ -224,26 +224,28 @@ FLOAT_TYPE mmvq_dot_product(const uint ib_a, const uint iqs) {
 #endif
 
 #if defined(DATA_A_ROCMFPX_FP6)
-int32_t rocmfpx_vq_fp6_pack4(uint ib, uint base) {
-    return rocmfpx_fp6_pack4_qs(data_a[ib].qs, base);
+int8_t rocmfpx_vq_fp6_decode_code(uint code) {
+    const int sign = -int(code >> 5);
+    return int8_t((int(code & 31u) ^ sign) - sign);
+}
+
+int32_t rocmfpx_vq_fp6_pack4_aligned(uint ib, uint byte_pos) {
+    const uint bits = uint(data_a[ib].qs[byte_pos + 0u]) |
+                     (uint(data_a[ib].qs[byte_pos + 1u]) <<  8) |
+                     (uint(data_a[ib].qs[byte_pos + 2u]) << 16);
+    return pack32(i8vec4(
+        rocmfpx_vq_fp6_decode_code( bits        & 0x3Fu),
+        rocmfpx_vq_fp6_decode_code((bits >>  6) & 0x3Fu),
+        rocmfpx_vq_fp6_decode_code((bits >> 12) & 0x3Fu),
+        rocmfpx_vq_fp6_decode_code((bits >> 18) & 0x3Fu)));
 }
 
 FLOAT_TYPE mmvq_dot_product(const uint ib_a, const uint iqs) {
-    int32_t sumi0 = 0;
-    int32_t sumi1 = 0;
-    [[unroll]] for (uint lane = 0u; lane < 2u; ++lane) {
-        const uint base = 4u * (iqs + lane);
-        const int32_t v = rocmfpx_vq_fp6_pack4(ib_a, base);
-        const int32_t u = cache_b_qs[lane];
-        if (base < QUANT_K / 2u) {
-            sumi0 = dotPacked4x8EXT(v, u);
-        } else {
-            sumi1 = dotPacked4x8EXT(v, u);
-        }
-    }
-    const FLOAT_TYPE d0 = FLOAT_TYPE(ue4m3_to_fp32(data_a[ib_a].e[0]));
-    const FLOAT_TYPE d1 = FLOAT_TYPE(ue4m3_to_fp32(data_a[ib_a].e[1]));
-    return FLOAT_TYPE(cache_b_ds.x * (d0 * float(sumi0) + d1 * float(sumi1)));
+    const uint byte_pos = iqs * 6u;
+    const int32_t q_sum = dotPacked4x8EXT(rocmfpx_vq_fp6_pack4_aligned(ib_a, byte_pos), cache_b_qs[0]) +
+                          dotPacked4x8EXT(rocmfpx_vq_fp6_pack4_aligned(ib_a, byte_pos + 3u), cache_b_qs[1]);
+    const FLOAT_TYPE d = FLOAT_TYPE(ue4m3_to_fp32(data_a[ib_a].e[iqs >= 2u ? 1u : 0u]));
+    return FLOAT_TYPE(cache_b_ds.x * d * float(q_sum));
 }
 #endif
 

--- a/ggml/src/ggml-vulkan/vulkan-shaders/types.glsl
+++ b/ggml/src/ggml-vulkan/vulkan-shaders/types.glsl
@@ -2031,6 +2031,32 @@ uint rocmfpx_fp6_code_at(uint q0, uint q1, uint q2, uint q3, uint q4, uint q5, u
     return ((low >> shift) | (high << (32u - shift))) & 0x3Fu;
 }
 
+int32_t rocmfpx_fp6_pack4_regs(uint qs0, uint qs1, uint qs2, uint qs3, uint qs4, uint qs5, uint ei) {
+    const uint b0 = ei * 6u;
+    return pack32(i8vec4(
+        kvalues_rocmfpx_fp6_const[rocmfpx_fp6_code_at(qs0, qs1, qs2, qs3, qs4, qs5, b0 + 0u)],
+        kvalues_rocmfpx_fp6_const[rocmfpx_fp6_code_at(qs0, qs1, qs2, qs3, qs4, qs5, b0 + 6u)],
+        kvalues_rocmfpx_fp6_const[rocmfpx_fp6_code_at(qs0, qs1, qs2, qs3, qs4, qs5, b0 + 12u)],
+        kvalues_rocmfpx_fp6_const[rocmfpx_fp6_code_at(qs0, qs1, qs2, qs3, qs4, qs5, b0 + 18u)]));
+}
+
+int32_t rocmfpx_fp6_pack4_window_qs(const uint8_t qs[24], uint ei) {
+    const uint bit_pos = ei * 6u;
+    const uint byte_pos = bit_pos >> 3u;
+    const uint shift = bit_pos & 7u;
+    const uint bits =
+        (uint(qs[byte_pos + 0u])      ) |
+        (uint(qs[byte_pos + 1u]) <<  8) |
+        (uint(qs[byte_pos + 2u]) << 16) |
+        ((byte_pos + 3u < 24u ? uint(qs[byte_pos + 3u]) : 0u) << 24);
+    const uint window = bits >> shift;
+    return pack32(i8vec4(
+        kvalues_rocmfpx_fp6_const[ window        & 0x3Fu],
+        kvalues_rocmfpx_fp6_const[(window >>  6) & 0x3Fu],
+        kvalues_rocmfpx_fp6_const[(window >> 12) & 0x3Fu],
+        kvalues_rocmfpx_fp6_const[(window >> 18) & 0x3Fu]));
+}
+
 int32_t rocmfpx_fp6_pack4_qs(const uint8_t qs[24], uint ei) {
     const uint qs0 = pack32(u8vec4(qs[0], qs[1], qs[2], qs[3]));
     const uint qs1 = pack32(u8vec4(qs[4], qs[5], qs[6], qs[7]));
@@ -2038,12 +2064,7 @@ int32_t rocmfpx_fp6_pack4_qs(const uint8_t qs[24], uint ei) {
     const uint qs3 = pack32(u8vec4(qs[12], qs[13], qs[14], qs[15]));
     const uint qs4 = pack32(u8vec4(qs[16], qs[17], qs[18], qs[19]));
     const uint qs5 = pack32(u8vec4(qs[20], qs[21], qs[22], qs[23]));
-    const uint b0 = ei * 6u;
-    return pack32(i8vec4(
-        kvalues_rocmfpx_fp6_const[rocmfpx_fp6_code_at(qs0, qs1, qs2, qs3, qs4, qs5, b0 + 0u)],
-        kvalues_rocmfpx_fp6_const[rocmfpx_fp6_code_at(qs0, qs1, qs2, qs3, qs4, qs5, b0 + 6u)],
-        kvalues_rocmfpx_fp6_const[rocmfpx_fp6_code_at(qs0, qs1, qs2, qs3, qs4, qs5, b0 + 12u)],
-        kvalues_rocmfpx_fp6_const[rocmfpx_fp6_code_at(qs0, qs1, qs2, qs3, qs4, qs5, b0 + 18u)]));
+    return rocmfpx_fp6_pack4_regs(qs0, qs1, qs2, qs3, qs4, qs5, ei);
 }
 #endif
 


### PR DESCRIPTION
## Motivation

The ROCmFPX Q6 Vulkan matvec path was decoding FP6 values through the generic bit-extraction helpers. That kept correctness simple, but it made token generation much slower than it needed to be: on the local FastContext Q6 agent quant, the old path measured about `33.36 tok/s` for `tg128`.

This PR keeps the Q6 format and math unchanged, but makes the hot decode path consume aligned FP6 groups directly.

## What changed

- Added FP6 helpers that unpack four 6-bit values from a 24-bit aligned window.
- Specialized `mul_mat_vec` for `DATA_A_ROCMFPX_FP6` so the `K_PER_ITER == 8` path decodes two aligned FP6 vec4 groups and immediately accumulates the two dot products.
- Reworked the Q8_1 vector path to use aligned FP6 packed decode with `dotPacked4x8EXT`, avoiding the previous loop and split-scale accumulation branch.
- Left the existing generic helpers in place for non-hot paths and reuse.

## Results

FastContext Q6 agent quant, Vulkan/RADV GFX1151, `-ngl 999 -fa 1 -p 512 -n 128 -r 5`:

| Path | pp512 | tg128 |
| --- | ---: | ---: |
| Before | not remeasured | ~33.36 tok/s |
| After | 1890.69 ± 30.36 tok/s | 51.62 ± 0.03 tok/s |

That is roughly a `1.55x` improvement on `tg128` for this workload.

Benchmark command:

```bash
timeout 300 build-strix-rocmfp4/bin/llama-bench \
  -m /media/auptimothy/Chonker/checkpoints/best-quants/FastContext-1.0-4B-SFT-Q6_0_ROCMFPX_AGENT-bm25imatrix.gguf \
  -ngl 999 -fa 1 -p 512 -n 128 -r 5
```

## Validation

```bash
cmake --build build-strix-rocmfp4 --target test-backend-ops llama-bench -j 16
```

```bash
timeout 120 build-strix-rocmfp4/bin/test-backend-ops test \
  -o MUL_MAT -b Vulkan0 \
  -p "type_a=q6_0_rocmfpx,type_b=f32,m=16,n=1,k=256"
```

`MUL_MAT`: `7/7` passed on Vulkan0.

```bash
timeout 120 build-strix-rocmfp4/bin/test-backend-ops test \
  -o CPY -b Vulkan0 \
  -p "q6_0_rocmfpx"
```

`CPY`: `17/17` passed on Vulkan0.

## Notes

This PR intentionally contains only the ROCmFPX FP6/Q6 decode-path changes. The ROCmFP4 experiments from local testing were discarded and are not part of this PR.