### PR TITLE
scripts: add ROCmFPX Strix mmid5 profile

### DIFF
--- a/docs/ROCmFPX-EXPERIMENT.md
+++ b/docs/ROCmFPX-EXPERIMENT.md
@@ -358,7 +358,7 @@ Available ROCmFPx profiles:
 ```text
 rocmfpx-strix-nwarps1, rocmfpx-strix-nwarps2, rocmfpx-strix-nwarps4
 rocmfpx-strix-rpb2
-rocmfpx-strix-mmid3, rocmfpx-strix-mmid4
+rocmfpx-strix-mmid3, rocmfpx-strix-mmid4, rocmfpx-strix-mmid5
 rocmfpx-strix-moe-rpb1, rocmfpx-strix-moe-rpb2, rocmfpx-strix-moe-rpb3, rocmfpx-strix-moe-rpb4
 ```
 

--- a/scripts/rocmfp4-decode-tune-flags.sh
+++ b/scripts/rocmfp4-decode-tune-flags.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 rocmfp4_decode_tune_known_profiles() {
-    echo "stable, strix-moe-rpb1, strix-moe-rpb2, strix-moe-rpb3, strix-moe-rpb4, strix-nwarps1, strix-nwarps2, strix-nwarps4, strix-mmid3, strix-mmid4, rocmfpx-strix-moe-rpb1, rocmfpx-strix-moe-rpb2, rocmfpx-strix-moe-rpb3, rocmfpx-strix-moe-rpb4, rocmfpx-strix-nwarps1, rocmfpx-strix-nwarps2, rocmfpx-strix-nwarps4, rocmfpx-strix-rpb2, rocmfpx-strix-mmid1, rocmfpx-strix-mmid2, rocmfpx-strix-mmid3, rocmfpx-strix-mmid4, rocmfpx-strix-vdr2, rocmfpx-strix-vdr8"
+    echo "stable, strix-moe-rpb1, strix-moe-rpb2, strix-moe-rpb3, strix-moe-rpb4, strix-nwarps1, strix-nwarps2, strix-nwarps4, strix-mmid3, strix-mmid4, rocmfpx-strix-moe-rpb1, rocmfpx-strix-moe-rpb2, rocmfpx-strix-moe-rpb3, rocmfpx-strix-moe-rpb4, rocmfpx-strix-nwarps1, rocmfpx-strix-nwarps2, rocmfpx-strix-nwarps4, rocmfpx-strix-rpb2, rocmfpx-strix-mmid1, rocmfpx-strix-mmid2, rocmfpx-strix-mmid3, rocmfpx-strix-mmid4, rocmfpx-strix-mmid5, rocmfpx-strix-vdr2, rocmfpx-strix-vdr8"
 }
 
 rocmfp4_decode_tune_flags() {
@@ -73,6 +73,9 @@ rocmfp4_decode_tune_flags() {
             ;;
         rocmfpx-strix-mmid4)
             echo "-DGGML_ROCMFPX_RDNA35_MMID_MAX_BATCH=4"
+            ;;
+        rocmfpx-strix-mmid5)
+            echo "-DGGML_ROCMFPX_RDNA35_MMID_MAX_BATCH=5"
             ;;
         rocmfpx-strix-vdr2)
             echo "-DGGML_ROCMFP6_Q8_1_MMVQ_VDR=2"


### PR DESCRIPTION
## Summary

Adds `rocmfpx-strix-mmid5` as an opt-in ROCmFPX decode tuning profile for Strix/RDNA3.5 builds.

The profile emits:

```text
-DGGML_ROCMFPX_RDNA35_MMID_MAX_BATCH=5
```

No defaults change. The existing `stable` profile still emits no extra flags.

## Why

Local served-MTP testing showed that the ROCmFPX `MUL_MAT_ID` max-batch threshold is worth testing as an explicit profile rather than as a hand-edited CMake flag. Keeping this as a named, default-off profile makes the experiment reproducible without changing conservative builds.

## Local served-MTP context

These rows are local Strix Halo evidence, included as context only. This PR does not make a default-performance claim.

| Row | TG tok/s | Prompt tok/s | Wall | TTFP | Draft |
| --- | ---: | ---: | ---: | ---: | ---: |
| `q6_kxl_default_mtp4k` | 22.668 | 164.433 | 44.477s | 21.891s | 420/546 |
| `q6_kxl_mmid5build_mtp4k` | 23.839 | 222.898 | 37.628s | 16.150s | 420/546 |
| `rocmfpx_q6only_mmid5_mtp4k_repeat2` | 24.391 | 229.735 | 36.661s | 15.670s | 421/540 |
| `rocmfpx_tailcvar_mmid5_mtp4k` | 25.759 | 234.779 | 35.213s | 15.340s | 421/535 |

The Tail-CVaR row is not a recommended recipe because its quality tail was rejected; it is listed only to show why this tuning knob is worth keeping reproducible.

## Validation

- `git diff --check`
- `bash -n scripts/rocmfp4-decode-tune-flags.sh`
- sourced `scripts/rocmfp4-decode-tune-flags.sh` and verified:
  - `rocmfp4_decode_tune_known_profiles` includes `rocmfpx-strix-mmid5`
  - `rocmfp4_decode_tune_flags rocmfpx-strix-mmid5` emits `-DGGML_ROCMFPX_RDNA35_MMID_MAX_BATCH=5`
  - `rocmfp4_decode_tune_flags stable` emits nothing
  - unknown profiles exit with status `2`
