### PR TITLE
[codex] ggml-cuda: speed up ROCmFPX pack helpers

### DIFF
--- a/ggml/src/ggml-cuda/vecdotq.cuh
+++ b/ggml/src/ggml-cuda/vecdotq.cuh
@@ -415,21 +415,25 @@ static __device__ __forceinline__ int rocmfpx_decode_fp6_code_vec_cuda(const uin
 }
 
 static __device__ __forceinline__ int rocmfpx_pack4_fp3_vec_cuda(const uint8_t * qs, const int base) {
-    const char4 v = make_char4(
-        (int8_t) rocmfpx_decode_fp3_code_vec_cuda(rocmfpx_get_bits_vec_cuda(qs, (base + 0)*3, 3)),
-        (int8_t) rocmfpx_decode_fp3_code_vec_cuda(rocmfpx_get_bits_vec_cuda(qs, (base + 1)*3, 3)),
-        (int8_t) rocmfpx_decode_fp3_code_vec_cuda(rocmfpx_get_bits_vec_cuda(qs, (base + 2)*3, 3)),
-        (int8_t) rocmfpx_decode_fp3_code_vec_cuda(rocmfpx_get_bits_vec_cuda(qs, (base + 3)*3, 3)));
-    return *((const int *) &v);
+    const int bit_pos = base*3;
+    const int byte_pos = bit_pos >> 3;
+    const int shift = bit_pos & 7;
+
+    uint32_t window = (uint32_t) qs[byte_pos] | ((uint32_t) qs[byte_pos + 1] << 8);
+    if (shift > 4 && byte_pos + 2 < QS_ROCMFP3) {
+        window |= (uint32_t) qs[byte_pos + 2] << 16;
+    }
+
+    return rocmfpx_pack4_fp3_codes((window >> shift) & 0xFFFu);
 }
 
 static __device__ __forceinline__ int rocmfpx_pack4_fp6_vec_cuda(const uint8_t * qs, const int base) {
-    const char4 v = make_char4(
-        (int8_t) rocmfpx_decode_fp6_code_vec_cuda(rocmfpx_get_bits_vec_cuda(qs, (base + 0)*6, 6)),
-        (int8_t) rocmfpx_decode_fp6_code_vec_cuda(rocmfpx_get_bits_vec_cuda(qs, (base + 1)*6, 6)),
-        (int8_t) rocmfpx_decode_fp6_code_vec_cuda(rocmfpx_get_bits_vec_cuda(qs, (base + 2)*6, 6)),
-        (int8_t) rocmfpx_decode_fp6_code_vec_cuda(rocmfpx_get_bits_vec_cuda(qs, (base + 3)*6, 6)));
-    return *((const int *) &v);
+    const int byte_pos = (base*6) >> 3;
+
+    uint32_t bits24 = 0;
+    memcpy(&bits24, qs + byte_pos, 3);
+
+    return rocmfpx_pack4_fp6_codes(bits24 & 0xFFFFFFu);
 }
 
 static __device__ __forceinline__ float vec_dot_rocmfp4_q8_1(


### PR DESCRIPTION
## Summary

- replace ROCmFPX FP3/FP6 pack helper scalar bit extraction in `vecdotq.cuh` with fixed byte-window packing
- reuse the existing ROCmFPX codebook pack helpers, preserving current FP6 signed-zero semantics
- leave VDR tuning and FP6 format semantics out of this narrow backend optimization

## Why

The MMQ/MMVQ tile-load helpers were decoding four FP3/FP6 codes by repeatedly
extracting individual bits. Loading the packed 12-bit/24-bit windows directly
removes that scalar bit loop while keeping the same codebook mapping.

The isolated dense-model backend-op win looked useful but easy to hide inside a
full served graph. A follow-up 35B MoE/MTP transfer test found the real target:
prompt-batch `MUL_MAT_ID` expert tile loads, especially q6 ROCmFPX expert
up/down projections.

## Validation

- Rebuilt `test-backend-ops` on current `origin/main` (`014cd28`) plus this patch.
- `test-backend-ops test -b ROCm0 -o MUL_MAT -p 'type_a=q[36]_0_rocmfpx,type_b=f32'`: `82/82 tests passed`.
- `test-backend-ops test -b ROCm0 -o FLASH_ATTN_EXT -p 'type_[KV]=q[36]_0_rocmfpx'`: supported q3/q3 case `1/1 tests passed`; unsupported filtered cases remained unsupported.
- Dense q6 prompt-batch backend-op case:
  - `test-backend-ops perf -b ROCm0 -o MUL_MAT -p 'type_a=q6_0_rocmfpx,type_b=f32,m=4096,n=512,k=14336'`
  - clean baseline: `8380.66 us/run`
  - this patch: `4660.83 us/run`
  - delta: `-44.39%`

## 35B MoE/MTP Transfer Test

Local Strix Halo ROCm0 served test:

- model: Qwen3.6-35B-A3B-MTP, `Q6_0_ROCMFPX_STRIX_QUALITY`
- target KV: `q8_0/q8_0`
- draft KV: `f16/f16`
- batch: `b2048/u512`
- context: `8192`
- speculative: `draft-mtp`, `n_max=4`, backend sampling off
- prompt replay: `3364` evaluated tokens
- decode: `256` generated tokens

Correctness gate on the exported MoE `MUL_MAT_ID` graph:

- clean baseline: `8/8` passed
- this patch: `8/8` passed

Backend-op perf on the same exported MoE graph:

| Case group | Clean baseline | This patch | Delta |
| --- | ---: | ---: | ---: |
| n=1 all four cases | `77.35 us` | `77.96 us` | `+0.79%` |
| n=512 all four expert cases | `8509.68 us` | `5221.14 us` | `-38.64%` |
| n=512 q6 expert cases only | `6606.54 us` | `3270.66 us` | `-50.49%` |
| n=512 q8 expert cases only | `1903.14 us` | `1950.48 us` | `+2.49%` |

Served A/B averages across eight API rows:

| Variant | Avg wall | Avg prompt tok/s | Avg gen tok/s |
| --- | ---: | ---: | ---: |
| clean baseline | `14.062s` | `576.473` | `31.372` |
| this patch | `11.845s` | `928.949` | `31.161` |
| delta | `-15.77%` | `+61.14%` | `-0.67%` |

Conservative order-flip-only comparison:

| Variant | Avg wall | Avg prompt tok/s | Avg gen tok/s |
| --- | ---: | ---: | ---: |
| clean baseline | `13.707s` | `605.194` | `31.446` |
| this patch | `11.786s` | `922.166` | `31.485` |
| delta | `-14.02%` | `+52.37%` | `+0.12%` |

Draft acceptance matched by row shape (`106/591` and `102/609`), and this patch
does not change model weights, quant recipes, KV policy, sampling, or draft
settings. The served win is therefore a quality-neutral prompt/prefill latency
improvement for the 35B MoE ROCmFPX path, not a universal decode-speed claim.

## Notes

This should be read as a narrow HIP/CUDA ROCmFPX tile-load optimization. It is
especially valuable for prompt-batch q6 expert `MUL_MAT_ID`; decode-shaped n=1
cases are effectively neutral.
