### PR TITLE
[codex] Fix MTP partial draft state tracking

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1406,6 +1406,8 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
             if (dp.result->size() < (size_t) n_min) {
                 dp.result->clear();
             }
+
+            last_n_drafted[seq_id] = (uint16_t) dp.result->size();
         }
     }
 


### PR DESCRIPTION
## Summary

Restores `last_n_drafted[seq_id]` tracking in the `draft-mtp` implementation after the Step MTP3 speculative-heads refactor.

`accept()` still uses `last_n_drafted` to decide how many verify hidden rows are available and how to rebase `pending_h` after partial draft acceptance. Without updating it after `draft()`, high-acceptance prompts can look fine, but normal prompts with partial acceptance lose the correct hidden-state handoff and speculative acceptance collapses.

## Impact

This fixes the Qwable/ROCmFPX normal-prompt MTP regression while preserving the high-acceptance fast path.

## Validation

Fresh clean `origin/main` at `ef43f95`, HIP/ROCm server build, Qwable FP6 speed model, ROCm0 target/draft, MTP cap 6, q8 target KV, f16 draft KV:

- High-accept 20 KB prompt, 512 gen: `296.96 PP`, `42.91 TG`, `438/438` draft tokens accepted.
- Wiki-2k prompt before fix, 512 gen: `309.76 PP`, `8.87 TG`, `141/2211` accepted.
- Wiki-2k prompt with this one-line fix, 512 gen: `302.50 PP`, `18.28 TG`, `332/1071` accepted.
- Old `c226d1f` wiki-2k reference: `213.50 PP`, `18.66 TG`, `335/1053` accepted.

The fix recovers the old partial-acceptance behavior without regressing the 40+ tok/s high-acceptance path.