### PR TITLE
[codex] Fix ROCmFPX FP6 CPU endpoint decode

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu.c
+++ b/ggml/src/ggml-cpu/ggml-cpu.c
@@ -228,7 +228,7 @@ static inline int ggml_rocmfpx_decode_fp3_cpu(uint32_t code) {
 
 static inline int ggml_rocmfpx_decode_fp6_cpu(uint32_t code) {
     const int mag = (int) (code & 31u);
-    return (code & 32u) ? -mag : mag;
+    return (code & 32u) ? -(mag == 0 ? 32 : mag) : mag;
 }
 
 static void ggml_vec_dot_rocmfpx_fp3_q8_0(int n, float * GGML_RESTRICT s, size_t bs, const void * GGML_RESTRICT vx, size_t bx, const void * GGML_RESTRICT vy, size_t by, int nrc) {


### PR DESCRIPTION
## Summary

Fix the CPU backend ROCmFPX FP6 decode helper so FP6 code `32` decodes as `-32`, matching the ROCmFPX native decoder, HIP codebook, CUDA/HIP dequant/copy helpers, and Vulkan helpers.

## Root Cause

The FP6 endpoint sync changed code `32` to represent `-32`, but `ggml/src/ggml-cpu/ggml-cpu.c` still used the older signed-magnitude decode where code `32` became `0`. That made q6 ROCmFPX GPU kernels compare against a stale CPU reference in backend tests.

## Impact

This restores q6 ROCmFPX backend correctness on current `main` after the FP6 endpoint sync. Before the fix, the narrow ROCmFPX gate failed with `115/229 tests passed`; after the fix, the same gate passes `229/229`.

## Validation

Built with the local HIP/mmid5 release configuration, then ran:

```bash
HIP_VISIBLE_DEVICES=0 build-stage2-mmid5-hip/bin/test-backend-ops test -o MUL_MAT,MUL_MAT_ID,FLASH_ATTN_EXT -p 'q[36]_0_rocmfpx'\n```\n\nResult:\n\n```text\n229/229 tests passed\nBackend ROCm0: OK\n2/2 backends passed\n```