### PR TITLE
Fix M-RoPE validation for hybrid MTP draft batches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -524,7 +524,8 @@ jobs:
             -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" \
             -DGGML_HIP_ROCWMMA_FATTN=ON \
             -DGPU_TARGETS="gfx1030" \
-            -DGGML_HIP=ON
+            -DGGML_HIP=ON \
+            -DLLAMA_BUILD_WEBUI=OFF
           cmake --build build --config Release -j $(nproc)
 
   ubuntu-22-musa:
@@ -553,7 +554,8 @@ jobs:
         id: cmake_build
         run: |
           cmake -B build -S . \
-            -DGGML_MUSA=ON
+            -DGGML_MUSA=ON \
+            -DLLAMA_BUILD_WEBUI=OFF
           time cmake --build build --config Release -j $(nproc)
 
 
@@ -712,7 +714,8 @@ jobs:
               -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined \
               -DGGML_NATIVE=OFF \
               -DGGML_CUDA=ON \
-              -DGGML_CUDA_CUB_3DOT2=ON
+              -DGGML_CUDA_CUB_3DOT2=ON \
+              -DLLAMA_BUILD_WEBUI=OFF
             cmake --build build
 
   windows-2022-cuda:

--- a/.github/workflows/hip-quality-check.yml
+++ b/.github/workflows/hip-quality-check.yml
@@ -63,6 +63,7 @@ jobs:
             -DGGML_HIP=ON \
             -DGGML_HIP_EXPORT_METRICS=Off \
             -DCMAKE_HIP_FLAGS="-Werror -Wno-tautological-compare" \
+            -DLLAMA_BUILD_WEBUI=OFF \
             -DCMAKE_BUILD_TYPE=Release
           cd build
           make -j $(nproc)
@@ -76,6 +77,7 @@ jobs:
             -DGGML_HIP=ON \
             -DGGML_HIP_EXPORT_METRICS=On \
             -DCMAKE_HIP_FLAGS="" \
+            -DLLAMA_BUILD_WEBUI=OFF \
             -DCMAKE_BUILD_TYPE=Release
           cd build
           make -j $(nproc) 2>&1 | tee metrics.log | grep -v 'Rpass-analysis=kernel-resource-usage\|remark:\|^$'

--- a/src/llama-batch.cpp
+++ b/src/llama-batch.cpp
@@ -261,7 +261,7 @@ bool llama_batch_allocr::init(
 
             const llama_pos p0 = memory ? memory->seq_pos_max(s) : -1;
 
-            if (batch.token) {
+            if (batch.token && !batch.embd) {
                 if (p0 >= 0 && p0 >= seq_pos_min(s)) {
                     LLAMA_LOG_ERROR(
                             "%s: the tokens of sequence %d in the input batch have inconsistent sequence positions:\n"
@@ -273,12 +273,14 @@ bool llama_batch_allocr::init(
                     return false;
                 }
             } else {
-                // embedding inputs can have overlapping positions
+                // Embedding inputs can have overlapping positions. This also covers
+                // hybrid MTP batches, which carry token ids for token embedding lookup
+                // while injecting hidden embeddings for the draft block.
                 if (p0 >= 0 && p0 > seq_pos_min(s)) {
                     LLAMA_LOG_ERROR(
-                            "%s: the tokens of sequence %d in the input batch have inconsistent sequence positions:\n"
+                            "%s: the embeddings of sequence %d in the input batch have inconsistent sequence positions:\n"
                             " - the last position stored in the memory module of the context (i.e. the KV cache) for sequence %d is X = %d\n"
-                            " - the tokens for sequence %d in the input batch have a starting position of Y = %d\n"
+                            " - the embeddings for sequence %d in the input batch have a starting position of Y = %d\n"
                             " for M-RoPE, it is required that the position satisfies: X <= Y\n",
                             __func__, s, s, p0, s, seq_pos_min(s));
 

--- a/tools/server/webui/src/lib/constants/uri-template.ts
+++ b/tools/server/webui/src/lib/constants/uri-template.ts
@@ -55,3 +55,11 @@ export const VARIABLE_PREFIX_MODIFIER_REGEX = /:[\d]+$/;
 
 /** Regex to strip one or more leading slashes */
 export const LEADING_SLASHES_REGEX = /^\/+/;
+
+/** Regex to match a base64 data URI for an image and capture its MIME subtype.
+ *  Used by cap-img-size.ts to extract the MIME type from a data URL like
+ *  "data:image/png;base64,iVBOR...". Group 1 contains the subtype (e.g. "png",
+ *  "jpeg", "svg+xml", "vnd.microsoft.icon"), which is then validated against
+ *  MimeTypeImage. Matches case-insensitively because MIME types are RFC-defined
+ *  as case-insensitive but the MimeTypeImage enum is lowercase. */
+export const BASE64_IMAGE_URI_REGEX = /^data:image\/([a-zA-Z0-9.+-]+);base64,/i;

--- a/tools/server/webui/src/lib/constants/uri-template.ts
+++ b/tools/server/webui/src/lib/constants/uri-template.ts
@@ -56,10 +56,5 @@ export const VARIABLE_PREFIX_MODIFIER_REGEX = /:[\d]+$/;
 /** Regex to strip one or more leading slashes */
 export const LEADING_SLASHES_REGEX = /^\/+/;
 
-/** Regex to match a base64 data URI for an image and capture its MIME subtype.
- *  Used by cap-img-size.ts to extract the MIME type from a data URL like
- *  "data:image/png;base64,iVBOR...". Group 1 contains the subtype (e.g. "png",
- *  "jpeg", "svg+xml", "vnd.microsoft.icon"), which is then validated against
- *  MimeTypeImage. Matches case-insensitively because MIME types are RFC-defined
- *  as case-insensitive but the MimeTypeImage enum is lowercase. */
-export const BASE64_IMAGE_URI_REGEX = /^data:image\/([a-zA-Z0-9.+-]+);base64,/i;
+/** Regex to capture the complete MIME type from a base64 image data URI. */
+export const BASE64_IMAGE_URI_REGEX = /^data:(image\/[a-z0-9.\-+]+);base64/;

--- a/tools/server/webui/src/lib/services/chat.service.ts
+++ b/tools/server/webui/src/lib/services/chat.service.ts
@@ -135,26 +135,28 @@ export class ChatService {
 			continueFinalMessage
 		} = options;
 
-		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
-			.map(async (msg) => {
-				if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
-					const dbMsg = msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] };
+		const normalizedMessages: ApiChatMessageData[] = (
+			await Promise.all(
+				messages.map((msg) => {
+					if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
+						const dbMsg = msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] };
 
-					return ChatService.convertDbMessageToApiChatMessageData(dbMsg);
-				} else {
-					return msg as ApiChatMessageData;
-				}
-			})
-			.then((arr) => arr.filter((msg) => {
-				// Filter out empty system messages
-				if (msg.role === MessageRole.SYSTEM) {
-					const content = typeof msg.content === 'string' ? msg.content : '';
+						return ChatService.convertDbMessageToApiChatMessageData(dbMsg);
+					} else {
+						return msg as ApiChatMessageData;
+					}
+				})
+			)
+		).filter((msg) => {
+			// Filter out empty system messages
+			if (msg.role === MessageRole.SYSTEM) {
+				const content = typeof msg.content === 'string' ? msg.content : '';
 
-					return content.trim().length > 0;
-				}
+				return content.trim().length > 0;
+			}
 
-				return true;
-			}))));
+			return true;
+		});
 
 		// Filter out image attachments if the model doesn't support vision
 		if (options.model && !modelsStore.modelSupportsVision(options.model)) {
@@ -383,25 +385,27 @@ export class ChatService {
 		excludeReasoning?: boolean,
 		signal?: AbortSignal
 	): Promise<void> {
-		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
-			.map(async (msg) => {
-				if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
-					return ChatService.convertDbMessageToApiChatMessageData(
-						msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
-					);
-				}
+		const normalizedMessages: ApiChatMessageData[] = (
+			await Promise.all(
+				messages.map((msg) => {
+					if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
+						return ChatService.convertDbMessageToApiChatMessageData(
+							msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
+						);
+					}
 
-				return msg as ApiChatMessageData;
-			})
-			.then((arr) => arr.filter((msg) => {
-				if (msg.role === MessageRole.SYSTEM) {
-					const content = typeof msg.content === 'string' ? msg.content : '';
+					return msg as ApiChatMessageData;
+				})
+			)
+		).filter((msg) => {
+			if (msg.role === MessageRole.SYSTEM) {
+				const content = typeof msg.content === 'string' ? msg.content : '';
 
-					return content.trim().length > 0;
-				}
+				return content.trim().length > 0;
+			}
 
-				return true;
-			}))));
+			return true;
+		});
 
 		const requestBody: Record<string, unknown> = {
 			messages: normalizedMessages.map((msg: ApiChatMessageData) => {
@@ -786,7 +790,7 @@ export class ChatService {
 	 */
 	static async convertDbMessageToApiChatMessageData(
 		message: DatabaseMessage & { extra?: DatabaseMessageExtra[] }
-	): ApiChatMessageData {
+	): Promise<ApiChatMessageData> {
 		// Handle tool result messages (role: 'tool')
 		if (message.role === MessageRole.TOOL && message.toolCallId) {
 			return {

--- a/tools/server/webui/src/lib/services/chat.service.ts
+++ b/tools/server/webui/src/lib/services/chat.service.ts
@@ -135,8 +135,8 @@ export class ChatService {
 			continueFinalMessage
 		} = options;
 
-		const normalizedMessages: ApiChatMessageData[] = messages
-			.map((msg) => {
+		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
+			.map(async (msg) => {
 				if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
 					const dbMsg = msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] };
 
@@ -145,7 +145,7 @@ export class ChatService {
 					return msg as ApiChatMessageData;
 				}
 			})
-			.filter((msg) => {
+			.then((arr) => arr.filter((msg) => {
 				// Filter out empty system messages
 				if (msg.role === MessageRole.SYSTEM) {
 					const content = typeof msg.content === 'string' ? msg.content : '';
@@ -154,7 +154,7 @@ export class ChatService {
 				}
 
 				return true;
-			});
+			}))));
 
 		// Filter out image attachments if the model doesn't support vision
 		if (options.model && !modelsStore.modelSupportsVision(options.model)) {
@@ -383,8 +383,8 @@ export class ChatService {
 		excludeReasoning?: boolean,
 		signal?: AbortSignal
 	): Promise<void> {
-		const normalizedMessages: ApiChatMessageData[] = messages
-			.map((msg) => {
+		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
+			.map(async (msg) => {
 				if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
 					return ChatService.convertDbMessageToApiChatMessageData(
 						msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
@@ -393,7 +393,7 @@ export class ChatService {
 
 				return msg as ApiChatMessageData;
 			})
-			.filter((msg) => {
+			.then((arr) => arr.filter((msg) => {
 				if (msg.role === MessageRole.SYSTEM) {
 					const content = typeof msg.content === 'string' ? msg.content : '';
 
@@ -401,7 +401,7 @@ export class ChatService {
 				}
 
 				return true;
-			});
+			}))));
 
 		const requestBody: Record<string, unknown> = {
 			messages: normalizedMessages.map((msg: ApiChatMessageData) => {
@@ -784,7 +784,7 @@ export class ChatService {
 	 * @returns {ApiChatMessageData} object formatted for the chat completion API
 	 * @static
 	 */
-	static convertDbMessageToApiChatMessageData(
+	static async convertDbMessageToApiChatMessageData(
 		message: DatabaseMessage & { extra?: DatabaseMessageExtra[] }
 	): ApiChatMessageData {
 		// Handle tool result messages (role: 'tool')

--- a/tools/server/webui/src/lib/stores/agentic.svelte.ts
+++ b/tools/server/webui/src/lib/stores/agentic.svelte.ts
@@ -418,21 +418,21 @@ class AgenticStore {
 
 		console.log(`[AgenticStore] Starting agentic flow with ${tools.length} tools`);
 
-		const normalizedMessages: ApiChatMessageData[] = messages
-			.map((msg) => {
+		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
+			.map(async (msg) => {
 				if ('id' in msg && 'convId' in msg && 'timestamp' in msg)
 					return ChatService.convertDbMessageToApiChatMessageData(
 						msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
 					);
 				return msg as ApiChatMessageData;
 			})
-			.filter((msg) => {
+			.then((arr) => arr.filter((msg) => {
 				if (msg.role === MessageRole.SYSTEM) {
 					const content = typeof msg.content === 'string' ? msg.content : '';
 					return content.trim().length > 0;
 				}
 				return true;
-			});
+			}))));
 
 		this.updateSession(conversationId, {
 			isRunning: true,

--- a/tools/server/webui/src/lib/stores/agentic.svelte.ts
+++ b/tools/server/webui/src/lib/stores/agentic.svelte.ts
@@ -418,21 +418,23 @@ class AgenticStore {
 
 		console.log(`[AgenticStore] Starting agentic flow with ${tools.length} tools`);
 
-		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
-			.map(async (msg) => {
-				if ('id' in msg && 'convId' in msg && 'timestamp' in msg)
-					return ChatService.convertDbMessageToApiChatMessageData(
-						msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
-					);
-				return msg as ApiChatMessageData;
-			})
-			.then((arr) => arr.filter((msg) => {
-				if (msg.role === MessageRole.SYSTEM) {
-					const content = typeof msg.content === 'string' ? msg.content : '';
-					return content.trim().length > 0;
-				}
-				return true;
-			}))));
+		const normalizedMessages: ApiChatMessageData[] = (
+			await Promise.all(
+				messages.map((msg) => {
+					if ('id' in msg && 'convId' in msg && 'timestamp' in msg)
+						return ChatService.convertDbMessageToApiChatMessageData(
+							msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
+						);
+					return msg as ApiChatMessageData;
+				})
+			)
+		).filter((msg) => {
+			if (msg.role === MessageRole.SYSTEM) {
+				const content = typeof msg.content === 'string' ? msg.content : '';
+				return content.trim().length > 0;
+			}
+			return true;
+		});
 
 		this.updateSession(conversationId, {
 			isRunning: true,


### PR DESCRIPTION
## Summary

Allow hybrid token-plus-embedding batches to use the M-RoPE position validation path.

## Problem

The M-RoPE batch validator currently selects its path from `batch.token` alone. Speculative MTP drafting can produce a hybrid batch that has token IDs and embeddings at the same time. Treating that batch as token-only applies the wrong position-count expectation and can reject a valid M-RoPE draft batch before decode.

## Fix

Classify the batch as token-only only when token IDs are present and embeddings are absent. Hybrid batches now follow the same M-RoPE position validation used by embedding-backed input.

This is a narrow validation fix in `src/llama-batch.cpp`; it does not change position generation, model weights, draft policy, sampling, or runtime kernels.

## Validation

Tested with the released ThinkingCap Qwen3.6 27B Chadrock target using MTP drafting:

- 3,900 prompt tokens
- 256 generated tokens
- 16.9820 generation tok/s
- 179 of 268 draft tokens accepted, 66.79%
- no M-RoPE position validation or decode failure

The full CPU backend operation suite also passed 2,156 of 2,156 tests, and the ROCmFPX reference gate passed after rebasing onto current upstream `main`.

## Origin

This is the qualified M-RoPE portion of experimental commit `db09e3ed2f3ad34ff0f5fc0bf705ce88c77893de`. Unrelated experimental README and runtime changes are intentionally excluded.

## CI dependency

This branch is temporarily stacked on the exact commits from PR #25 so its CI runs against the required WebUI and backend-build repair. After #25 merges, those shared commits become part of the base and this PR reduces automatically to its single focused feature commit.