### PR TITLE
Speed ROCmFPX Q3/Q6 scale evaluation with identical output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -524,7 +524,8 @@ jobs:
             -DCMAKE_HIP_COMPILER="$(hipconfig -l)/clang" \
             -DGGML_HIP_ROCWMMA_FATTN=ON \
             -DGPU_TARGETS="gfx1030" \
-            -DGGML_HIP=ON
+            -DGGML_HIP=ON \
+            -DLLAMA_BUILD_WEBUI=OFF
           cmake --build build --config Release -j $(nproc)
 
   ubuntu-22-musa:
@@ -553,7 +554,8 @@ jobs:
         id: cmake_build
         run: |
           cmake -B build -S . \
-            -DGGML_MUSA=ON
+            -DGGML_MUSA=ON \
+            -DLLAMA_BUILD_WEBUI=OFF
           time cmake --build build --config Release -j $(nproc)
 
 
@@ -712,7 +714,8 @@ jobs:
               -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined \
               -DGGML_NATIVE=OFF \
               -DGGML_CUDA=ON \
-              -DGGML_CUDA_CUB_3DOT2=ON
+              -DGGML_CUDA_CUB_3DOT2=ON \
+              -DLLAMA_BUILD_WEBUI=OFF
             cmake --build build
 
   windows-2022-cuda:

--- a/.github/workflows/hip-quality-check.yml
+++ b/.github/workflows/hip-quality-check.yml
@@ -63,6 +63,7 @@ jobs:
             -DGGML_HIP=ON \
             -DGGML_HIP_EXPORT_METRICS=Off \
             -DCMAKE_HIP_FLAGS="-Werror -Wno-tautological-compare" \
+            -DLLAMA_BUILD_WEBUI=OFF \
             -DCMAKE_BUILD_TYPE=Release
           cd build
           make -j $(nproc)
@@ -76,6 +77,7 @@ jobs:
             -DGGML_HIP=ON \
             -DGGML_HIP_EXPORT_METRICS=On \
             -DCMAKE_HIP_FLAGS="" \
+            -DLLAMA_BUILD_WEBUI=OFF \
             -DCMAKE_BUILD_TYPE=Release
           cd build
           make -j $(nproc) 2>&1 | tee metrics.log | grep -v 'Rpass-analysis=kernel-resource-usage\|remark:\|^$'

--- a/ggml/rocmfpx/rocmfpx.c
+++ b/ggml/rocmfpx/rocmfpx.c
@@ -274,6 +274,24 @@ static uint8_t rocmfpx_quantize_fp3_code(float x, float inv_scale) {
     return mag == 0 ? 0 : (uint8_t) ((x < 0.0f ? 4u : 0u) | mag);
 }
 
+// Fused threshold + decode for finite values in the exhaustive scale search.
+// The result exactly matches quantize_fp3_code followed by decode_fp3_code.
+static inline float rocmfpx_fp3_decoded_mag(float x, float inv_scale) {
+    const float a = fabsf(x * inv_scale);
+    float mag;
+    if (a <= 0.5f) {
+        return 0.0f;
+    } else if (a <= 1.5f) {
+        mag = 1.0f;
+    } else if (a <= 3.0f) {
+        mag = 2.0f;
+    } else {
+        mag = 4.0f;
+    }
+
+    return x < 0.0f ? -mag : mag;
+}
+
 static float rocmfpx_fp3_block_mse_for_scale(const float * x, int n, uint8_t e, float best_err) {
     const float scale = rocmfpx_scale_lookup(e);
     const float inv_scale = scale > 0.0f ? 1.0f / scale : 0.0f;
@@ -284,8 +302,7 @@ static float rocmfpx_fp3_block_mse_for_scale(const float * x, int n, uint8_t e, 
             continue;
         }
 
-        const uint8_t code = rocmfpx_quantize_fp3_code(x[i], inv_scale);
-        const float y = (float) rocmfpx_decode_fp3_code(code) * scale;
+        const float y = rocmfpx_fp3_decoded_mag(x[i], inv_scale) * scale;
         const float d = x[i] - y;
 
         err += d*d;
@@ -304,8 +321,7 @@ static float rocmfpx_fp3_block_mse_for_scale_finite(const float * x, int n, uint
     float err = 0.0f;
 
     for (int i = 0; i < n; ++i) {
-        const uint8_t code = rocmfpx_quantize_fp3_code(x[i], inv_scale);
-        const float y = (float) rocmfpx_decode_fp3_code(code) * scale;
+        const float y = rocmfpx_fp3_decoded_mag(x[i], inv_scale) * scale;
         const float d = x[i] - y;
 
         err += d*d;
@@ -327,8 +343,7 @@ static float rocmfpx_fp3_block_weighted_mse_for_scale(const float * x, int n, co
             continue;
         }
 
-        const uint8_t code = rocmfpx_quantize_fp3_code(x[i], inv_scale);
-        const float y = (float) rocmfpx_decode_fp3_code(code) * scale;
+        const float y = rocmfpx_fp3_decoded_mag(x[i], inv_scale) * scale;
         const float d = x[i] - y;
 
         err += mse_weights[i]*d*d;
@@ -347,8 +362,7 @@ static float rocmfpx_fp3_block_weighted_mse_for_scale_finite(const float * x, in
     float err = 0.0f;
 
     for (int i = 0; i < n; ++i) {
-        const uint8_t code = rocmfpx_quantize_fp3_code(x[i], inv_scale);
-        const float y = (float) rocmfpx_decode_fp3_code(code) * scale;
+        const float y = rocmfpx_fp3_decoded_mag(x[i], inv_scale) * scale;
         const float d = x[i] - y;
 
         err += mse_weights[i]*d*d;
@@ -463,6 +477,20 @@ static uint8_t rocmfpx_quantize_fp6_code(float x, float inv_scale) {
     return q == 0 ? 0 : (uint8_t) (q < 0 ? (32u | ((uint8_t) -q & 31u)) : (uint8_t) q);
 }
 
+// Fused round, clamp, and decode for finite values in the scale search. Keep
+// current main's asymmetric signed range [-32, 31], including the encoded -32
+// endpoint, rather than the older experimental branch's [-31, 31] behavior.
+static inline float rocmfpx_fp6_decoded_value(float x, float inv_scale) {
+    int q = (int) lroundf(x * inv_scale);
+    if (q > 31) {
+        q = 31;
+    } else if (q < -32) {
+        q = -32;
+    }
+
+    return (float) q;
+}
+
 static float rocmfpx_fp6_block_mse_for_scale(const float * x, int n, uint8_t e, float best_err) {
     const float scale = rocmfpx_scale_lookup(e);
     const float inv_scale = scale > 0.0f ? 1.0f / scale : 0.0f;
@@ -472,8 +500,7 @@ static float rocmfpx_fp6_block_mse_for_scale(const float * x, int n, uint8_t e, 
         if (!isfinite(x[i])) {
             continue;
         }
-        const uint8_t code = rocmfpx_quantize_fp6_code(x[i], inv_scale);
-        const float y = (float) rocmfpx_decode_fp6_code(code) * scale;
+        const float y = rocmfpx_fp6_decoded_value(x[i], inv_scale) * scale;
         const float d = x[i] - y;
         err += d*d;
         if (err > best_err) {
@@ -491,8 +518,7 @@ static float rocmfpx_fp6_block_mse_for_scale_finite(const float * x, int n, uint
     float err = 0.0f;
 
     for (int i = 0; i < n; ++i) {
-        const uint8_t code = rocmfpx_quantize_fp6_code(x[i], inv_scale);
-        const float y = (float) rocmfpx_decode_fp6_code(code) * scale;
+        const float y = rocmfpx_fp6_decoded_value(x[i], inv_scale) * scale;
         const float d = x[i] - y;
         err += d*d;
         if (err > best_err) {
@@ -512,8 +538,7 @@ static float rocmfpx_fp6_block_weighted_mse_for_scale(const float * x, int n, co
         if (!isfinite(x[i])) {
             continue;
         }
-        const uint8_t code = rocmfpx_quantize_fp6_code(x[i], inv_scale);
-        const float y = (float) rocmfpx_decode_fp6_code(code) * scale;
+        const float y = rocmfpx_fp6_decoded_value(x[i], inv_scale) * scale;
         const float d = x[i] - y;
         err += mse_weights[i]*d*d;
         if (err > best_err) {
@@ -531,8 +556,7 @@ static float rocmfpx_fp6_block_weighted_mse_for_scale_finite(const float * x, in
     float err = 0.0f;
 
     for (int i = 0; i < n; ++i) {
-        const uint8_t code = rocmfpx_quantize_fp6_code(x[i], inv_scale);
-        const float y = (float) rocmfpx_decode_fp6_code(code) * scale;
+        const float y = rocmfpx_fp6_decoded_value(x[i], inv_scale) * scale;
         const float d = x[i] - y;
         err += mse_weights[i]*d*d;
         if (err > best_err) {

--- a/tools/server/webui/src/lib/constants/uri-template.ts
+++ b/tools/server/webui/src/lib/constants/uri-template.ts
@@ -55,3 +55,11 @@ export const VARIABLE_PREFIX_MODIFIER_REGEX = /:[\d]+$/;
 
 /** Regex to strip one or more leading slashes */
 export const LEADING_SLASHES_REGEX = /^\/+/;
+
+/** Regex to match a base64 data URI for an image and capture its MIME subtype.
+ *  Used by cap-img-size.ts to extract the MIME type from a data URL like
+ *  "data:image/png;base64,iVBOR...". Group 1 contains the subtype (e.g. "png",
+ *  "jpeg", "svg+xml", "vnd.microsoft.icon"), which is then validated against
+ *  MimeTypeImage. Matches case-insensitively because MIME types are RFC-defined
+ *  as case-insensitive but the MimeTypeImage enum is lowercase. */
+export const BASE64_IMAGE_URI_REGEX = /^data:image\/([a-zA-Z0-9.+-]+);base64,/i;

--- a/tools/server/webui/src/lib/constants/uri-template.ts
+++ b/tools/server/webui/src/lib/constants/uri-template.ts
@@ -56,10 +56,5 @@ export const VARIABLE_PREFIX_MODIFIER_REGEX = /:[\d]+$/;
 /** Regex to strip one or more leading slashes */
 export const LEADING_SLASHES_REGEX = /^\/+/;
 
-/** Regex to match a base64 data URI for an image and capture its MIME subtype.
- *  Used by cap-img-size.ts to extract the MIME type from a data URL like
- *  "data:image/png;base64,iVBOR...". Group 1 contains the subtype (e.g. "png",
- *  "jpeg", "svg+xml", "vnd.microsoft.icon"), which is then validated against
- *  MimeTypeImage. Matches case-insensitively because MIME types are RFC-defined
- *  as case-insensitive but the MimeTypeImage enum is lowercase. */
-export const BASE64_IMAGE_URI_REGEX = /^data:image\/([a-zA-Z0-9.+-]+);base64,/i;
+/** Regex to capture the complete MIME type from a base64 image data URI. */
+export const BASE64_IMAGE_URI_REGEX = /^data:(image\/[a-z0-9.\-+]+);base64/;

--- a/tools/server/webui/src/lib/services/chat.service.ts
+++ b/tools/server/webui/src/lib/services/chat.service.ts
@@ -135,26 +135,28 @@ export class ChatService {
 			continueFinalMessage
 		} = options;
 
-		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
-			.map(async (msg) => {
-				if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
-					const dbMsg = msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] };
+		const normalizedMessages: ApiChatMessageData[] = (
+			await Promise.all(
+				messages.map((msg) => {
+					if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
+						const dbMsg = msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] };
 
-					return ChatService.convertDbMessageToApiChatMessageData(dbMsg);
-				} else {
-					return msg as ApiChatMessageData;
-				}
-			})
-			.then((arr) => arr.filter((msg) => {
-				// Filter out empty system messages
-				if (msg.role === MessageRole.SYSTEM) {
-					const content = typeof msg.content === 'string' ? msg.content : '';
+						return ChatService.convertDbMessageToApiChatMessageData(dbMsg);
+					} else {
+						return msg as ApiChatMessageData;
+					}
+				})
+			)
+		).filter((msg) => {
+			// Filter out empty system messages
+			if (msg.role === MessageRole.SYSTEM) {
+				const content = typeof msg.content === 'string' ? msg.content : '';
 
-					return content.trim().length > 0;
-				}
+				return content.trim().length > 0;
+			}
 
-				return true;
-			}))));
+			return true;
+		});
 
 		// Filter out image attachments if the model doesn't support vision
 		if (options.model && !modelsStore.modelSupportsVision(options.model)) {
@@ -383,25 +385,27 @@ export class ChatService {
 		excludeReasoning?: boolean,
 		signal?: AbortSignal
 	): Promise<void> {
-		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
-			.map(async (msg) => {
-				if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
-					return ChatService.convertDbMessageToApiChatMessageData(
-						msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
-					);
-				}
+		const normalizedMessages: ApiChatMessageData[] = (
+			await Promise.all(
+				messages.map((msg) => {
+					if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
+						return ChatService.convertDbMessageToApiChatMessageData(
+							msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
+						);
+					}
 
-				return msg as ApiChatMessageData;
-			})
-			.then((arr) => arr.filter((msg) => {
-				if (msg.role === MessageRole.SYSTEM) {
-					const content = typeof msg.content === 'string' ? msg.content : '';
+					return msg as ApiChatMessageData;
+				})
+			)
+		).filter((msg) => {
+			if (msg.role === MessageRole.SYSTEM) {
+				const content = typeof msg.content === 'string' ? msg.content : '';
 
-					return content.trim().length > 0;
-				}
+				return content.trim().length > 0;
+			}
 
-				return true;
-			}))));
+			return true;
+		});
 
 		const requestBody: Record<string, unknown> = {
 			messages: normalizedMessages.map((msg: ApiChatMessageData) => {
@@ -786,7 +790,7 @@ export class ChatService {
 	 */
 	static async convertDbMessageToApiChatMessageData(
 		message: DatabaseMessage & { extra?: DatabaseMessageExtra[] }
-	): ApiChatMessageData {
+	): Promise<ApiChatMessageData> {
 		// Handle tool result messages (role: 'tool')
 		if (message.role === MessageRole.TOOL && message.toolCallId) {
 			return {

--- a/tools/server/webui/src/lib/services/chat.service.ts
+++ b/tools/server/webui/src/lib/services/chat.service.ts
@@ -135,8 +135,8 @@ export class ChatService {
 			continueFinalMessage
 		} = options;
 
-		const normalizedMessages: ApiChatMessageData[] = messages
-			.map((msg) => {
+		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
+			.map(async (msg) => {
 				if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
 					const dbMsg = msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] };
 
@@ -145,7 +145,7 @@ export class ChatService {
 					return msg as ApiChatMessageData;
 				}
 			})
-			.filter((msg) => {
+			.then((arr) => arr.filter((msg) => {
 				// Filter out empty system messages
 				if (msg.role === MessageRole.SYSTEM) {
 					const content = typeof msg.content === 'string' ? msg.content : '';
@@ -154,7 +154,7 @@ export class ChatService {
 				}
 
 				return true;
-			});
+			}))));
 
 		// Filter out image attachments if the model doesn't support vision
 		if (options.model && !modelsStore.modelSupportsVision(options.model)) {
@@ -383,8 +383,8 @@ export class ChatService {
 		excludeReasoning?: boolean,
 		signal?: AbortSignal
 	): Promise<void> {
-		const normalizedMessages: ApiChatMessageData[] = messages
-			.map((msg) => {
+		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
+			.map(async (msg) => {
 				if ('id' in msg && 'convId' in msg && 'timestamp' in msg) {
 					return ChatService.convertDbMessageToApiChatMessageData(
 						msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
@@ -393,7 +393,7 @@ export class ChatService {
 
 				return msg as ApiChatMessageData;
 			})
-			.filter((msg) => {
+			.then((arr) => arr.filter((msg) => {
 				if (msg.role === MessageRole.SYSTEM) {
 					const content = typeof msg.content === 'string' ? msg.content : '';
 
@@ -401,7 +401,7 @@ export class ChatService {
 				}
 
 				return true;
-			});
+			}))));
 
 		const requestBody: Record<string, unknown> = {
 			messages: normalizedMessages.map((msg: ApiChatMessageData) => {
@@ -784,7 +784,7 @@ export class ChatService {
 	 * @returns {ApiChatMessageData} object formatted for the chat completion API
 	 * @static
 	 */
-	static convertDbMessageToApiChatMessageData(
+	static async convertDbMessageToApiChatMessageData(
 		message: DatabaseMessage & { extra?: DatabaseMessageExtra[] }
 	): ApiChatMessageData {
 		// Handle tool result messages (role: 'tool')

--- a/tools/server/webui/src/lib/stores/agentic.svelte.ts
+++ b/tools/server/webui/src/lib/stores/agentic.svelte.ts
@@ -418,21 +418,21 @@ class AgenticStore {
 
 		console.log(`[AgenticStore] Starting agentic flow with ${tools.length} tools`);
 
-		const normalizedMessages: ApiChatMessageData[] = messages
-			.map((msg) => {
+		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
+			.map(async (msg) => {
 				if ('id' in msg && 'convId' in msg && 'timestamp' in msg)
 					return ChatService.convertDbMessageToApiChatMessageData(
 						msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
 					);
 				return msg as ApiChatMessageData;
 			})
-			.filter((msg) => {
+			.then((arr) => arr.filter((msg) => {
 				if (msg.role === MessageRole.SYSTEM) {
 					const content = typeof msg.content === 'string' ? msg.content : '';
 					return content.trim().length > 0;
 				}
 				return true;
-			});
+			}))));
 
 		this.updateSession(conversationId, {
 			isRunning: true,

--- a/tools/server/webui/src/lib/stores/agentic.svelte.ts
+++ b/tools/server/webui/src/lib/stores/agentic.svelte.ts
@@ -418,21 +418,23 @@ class AgenticStore {
 
 		console.log(`[AgenticStore] Starting agentic flow with ${tools.length} tools`);
 
-		const normalizedMessages: ApiChatMessageData[] = (await Promise.all(messages
-			.map(async (msg) => {
-				if ('id' in msg && 'convId' in msg && 'timestamp' in msg)
-					return ChatService.convertDbMessageToApiChatMessageData(
-						msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
-					);
-				return msg as ApiChatMessageData;
-			})
-			.then((arr) => arr.filter((msg) => {
-				if (msg.role === MessageRole.SYSTEM) {
-					const content = typeof msg.content === 'string' ? msg.content : '';
-					return content.trim().length > 0;
-				}
-				return true;
-			}))));
+		const normalizedMessages: ApiChatMessageData[] = (
+			await Promise.all(
+				messages.map((msg) => {
+					if ('id' in msg && 'convId' in msg && 'timestamp' in msg)
+						return ChatService.convertDbMessageToApiChatMessageData(
+							msg as DatabaseMessage & { extra?: DatabaseMessageExtra[] }
+						);
+					return msg as ApiChatMessageData;
+				})
+			)
+		).filter((msg) => {
+			if (msg.role === MessageRole.SYSTEM) {
+				const content = typeof msg.content === 'string' ? msg.content : '';
+				return content.trim().length > 0;
+			}
+			return true;
+		});
 
 		this.updateSession(conversationId, {
 			isRunning: true,


### PR DESCRIPTION
## Summary

Speed exhaustive ROCmFPX Q3 and Q6 scale selection by evaluating candidate error directly, without repeatedly encoding and decoding each candidate value.

## Problem

The Q3 and Q6 quantizers search candidate block scales exhaustively. The current error loop repeatedly round-trips candidate values through the format encode/decode helpers even though the corresponding reconstructed value can be calculated directly. That work is repeated for every candidate scale and every value in the block.

## Fix

Fuse candidate reconstruction and squared-error calculation for ROCmFPX FP3 and FP6 while preserving the current codebooks and FP6 signed `-32` endpoint semantics.

This affects offline quantization only. It does not change:

- the ROCmFPX GGUF format
- selected quantized values
- runtime inference kernels
- model recipes or published model names

## Performance and correctness

Full-GGUF Qwen3 0.6B quantization, three rounds per build:

| Format | Baseline median | Patched median | Reduction |
| --- | ---: | ---: | ---: |
| Q3 ROCmFPX | 4,843 ms | 4,530 ms | 6.46% |
| Q6 ROCmFPX | 3,838 ms | 3,193 ms | 16.81% |

The patched and baseline GGUF files were byte-identical for both formats.

Additional validation:

- CPU backend operation suite: 2,156 of 2,156 tests passed
- ROCmFPX reference probes passed
- quantization-function tests passed
- dedicated ROCmFPX reference CI passed after rebasing onto current upstream `main`

## Scope decisions

The analogous ROCmFP4 fused path is intentionally excluded because it was 5.98% slower in the same qualification run. This PR therefore changes only the Q3 and Q6 paths that demonstrated a repeatable gain with identical output.

## Origin

Adapted from the qualified Q3/Q6 portion of experimental commit `8b9fd72`; unrelated experimental changes are excluded.

## CI dependency

This branch is temporarily stacked on the exact commits from PR #25 so its CI runs against the required WebUI and backend-build repair. After #25 merges, those shared commits become part of the base and this PR reduces automatically to its single focused feature commit.