### PR TITLE
Fix ROCm 7.2 fast-math negative-infinity builds

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -565,6 +565,10 @@ struct block_reduce_policy;
 template <typename T, typename... Ts>
 inline constexpr bool is_any = (std::is_same_v<T, Ts> || ...);
 
+static __device__ __forceinline__ float ggml_cuda_negative_infinity() {
+    return __int_as_float(0xff800000);
+}
+
 template<typename...>
 inline constexpr bool ggml_cuda_dependent_false_v = false;
 
@@ -603,9 +607,9 @@ template <typename T> struct block_reduce_policy<block_reduce_method::MAX, T> {
 
     static __device__ T sentinel() {
         if constexpr (std::is_same_v<T, float>) {
-            return -INFINITY;
+            return ggml_cuda_negative_infinity();
         } else if constexpr (std::is_same_v<T, half2>) {
-            return make_half2(-INFINITY, -INFINITY);
+            return make_half2(ggml_cuda_negative_infinity(), ggml_cuda_negative_infinity());
         } else {
             static_assert(ggml_cuda_dependent_false_v<T>, "Unsupported type for block reduce max");
         }

--- a/ggml/src/ggml-cuda/cross-entropy-loss.cu
+++ b/ggml/src/ggml-cuda/cross-entropy-loss.cu
@@ -14,7 +14,7 @@ static __global__ void cross_entropy_loss_f32(
     labels += int64_t(blockIdx.x)*nclasses;
 
     // Find maximum for softmax:
-    float max_logit = -INFINITY;
+    float max_logit = ggml_cuda_negative_infinity();
     for (int i = threadIdx.x; i < nclasses; i += WARP_SIZE) {
         const float val = logits[i];
         max_logit = fmaxf(max_logit, val);
@@ -59,7 +59,7 @@ static __global__ void cross_entropy_loss_back_f32(
     labels += int64_t(blockIdx.x)*nclasses;
     dst    += int64_t(blockIdx.x)*nclasses;
 
-    float maxval = -INFINITY;
+    float maxval = ggml_cuda_negative_infinity();
     for (int i = threadIdx.x; i < nclasses; i += WARP_SIZE) {
         const float val = logits[i];
         maxval = fmaxf(maxval, val);

--- a/ggml/src/ggml-cuda/dsv4.cu
+++ b/ggml/src/ggml-cuda/dsv4.cu
@@ -105,7 +105,7 @@ static __global__ void dsv4_hc_split_sinkhorn_f32(
         }
 
         for (int dst_hc = 0; dst_hc < n_hc; ++dst_hc) {
-            float row_max = -INFINITY;
+            float row_max = ggml_cuda_negative_infinity();
             for (int src_hc = 0; src_hc < n_hc; ++src_hc) {
                 const int idx = src_hc + dst_hc*n_hc;
                 const int off = 2*n_hc + idx;

--- a/ggml/src/ggml-cuda/softmax.cu
+++ b/ggml/src/ggml-cuda/softmax.cu
@@ -82,7 +82,7 @@ static __global__ void soft_max_f32(
     // shared memory buffer to cache values between iterations:
     float * vals = use_shared ? buf_iw + WARP_SIZE : dst;
 
-    float max_val = sinks ? sinks[i02] : -INFINITY;
+    float max_val = sinks ? sinks[i02] : ggml_cuda_negative_infinity();
 
 #pragma unroll
     for (int col0 = 0; col0 < ncols; col0 += block_size) {
@@ -151,8 +151,9 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
     const int col_start         = blockIdx.x * blockDim.x + tid;
     const int n_elem_per_thread = 4;
 
-    float     local_vals[n_elem_per_thread] = { -INFINITY, -INFINITY, -INFINITY, -INFINITY };
-    float     local_max                     = -INFINITY;
+    float     local_vals[n_elem_per_thread] = { ggml_cuda_negative_infinity(), ggml_cuda_negative_infinity(),
+                                                ggml_cuda_negative_infinity(), ggml_cuda_negative_infinity() };
+    float     local_max                     = ggml_cuda_negative_infinity();
     const int step_size                     = gridDim.x * blockDim.x;
     __shared__ float shared_vals[32];
 
@@ -161,7 +162,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
 #pragma unroll
         for (int i = 0; i < n_elem_per_thread; i++) {
             const int idx = col + i * step_size;
-            local_vals[i] = idx < p.ncols ? x[idx] : -INFINITY;
+            local_vals[i] = idx < p.ncols ? x[idx] : ggml_cuda_negative_infinity();
         }
 #pragma unroll
         for (int i = 0; i < n_elem_per_thread; i++) {
@@ -184,7 +185,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
     if (tid < gridDim.x) {
         local_max = tmp_maxs[tid];
     } else {
-        local_max = -INFINITY;
+        local_max = ggml_cuda_negative_infinity();
     }
     local_max = block_reduce<block_reduce_method::MAX>(local_max, shared_vals);
 
@@ -194,7 +195,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
 #pragma unroll
         for (int i = 0; i < n_elem_per_thread; i++) {
             const int idx = col + i * step_size;
-            local_vals[i] = idx < p.ncols ? x[idx] : -INFINITY;
+            local_vals[i] = idx < p.ncols ? x[idx] : ggml_cuda_negative_infinity();
         }
 #pragma unroll
         for (int i = 0; i < n_elem_per_thread; i++) {
@@ -230,7 +231,7 @@ static __device__ void soft_max_f32_parallelize_cols_single_row(const float * __
 #pragma unroll
         for (int i = 0; i < n_elem_per_thread; i++) {
             const int idx = col + i * step_size;
-            local_vals[i] = idx < p.ncols ? dst[idx] : -INFINITY;
+            local_vals[i] = idx < p.ncols ? dst[idx] : ggml_cuda_negative_infinity();
         }
 #pragma unroll
         for (int i = 0; i < n_elem_per_thread; i++) {

--- a/ggml/src/ggml-cuda/topk-moe.cu
+++ b/ggml/src/ggml-cuda/topk-moe.cu
@@ -15,7 +15,7 @@ struct topk_moe_config {
 // Warp-local softmax used for both the pre-top-k logits and the post-top-k delayed path.
 template <int experts_per_thread, bool use_limit>
 __device__ void softmax_warp_inplace(float (&vals)[experts_per_thread], const int limit, const int lane) {
-    float max_val = -INFINITY;
+    float max_val = ggml_cuda_negative_infinity();
 
 #pragma unroll
     for (int i = 0; i < experts_per_thread; i++) {
@@ -63,7 +63,7 @@ __device__ void sigmoid_warp_inplace(float (&vals)[experts_per_thread], const in
     for (int i = 0; i < experts_per_thread; i++) {
         const int  idx    = lane + i * WARP_SIZE;
         const bool active = !use_limit || (idx < limit);
-        vals[i]           = active ? 1.f / (1.f + expf(-vals[i])) : -INFINITY;
+        vals[i]           = active ? 1.f / (1.f + expf(-vals[i])) : ggml_cuda_negative_infinity();
     }
 }
 
@@ -102,13 +102,14 @@ __launch_bounds__(4 * WARP_SIZE, 1) __global__ void topk_moe_cuda(const float * 
     // Initialize all slots to -INFINITY
 #pragma unroll
     for (int i = 0; i < experts_per_thread; i++) {
-        wt[i] = -INFINITY;
+        wt[i] = ggml_cuda_negative_infinity();
     }
 
 #pragma unroll
     for (int i = 0; i < n_experts; i += WARP_SIZE) {
         const int expert  = i + threadIdx.x;
-        wt[i / WARP_SIZE] = (n_experts % WARP_SIZE == 0 || expert < n_experts) ? logits[expert] : -INFINITY;
+        wt[i / WARP_SIZE] = (n_experts % WARP_SIZE == 0 || expert < n_experts) ?
+                                logits[expert] : ggml_cuda_negative_infinity();
     }
 
     if (!config.delayed_softmax) {
@@ -138,13 +139,14 @@ __launch_bounds__(4 * WARP_SIZE, 1) __global__ void topk_moe_cuda(const float * 
     if constexpr (has_bias) {
 #pragma unroll
         for (int i = 0; i < experts_per_thread; i++) {
-            selection_wt[i] = -INFINITY;
+            selection_wt[i] = ggml_cuda_negative_infinity();
         }
 #pragma unroll
         for (int i = 0; i < n_experts; i += WARP_SIZE) {
             const int expert = i + threadIdx.x;
             selection_wt[i / WARP_SIZE] =
-                (n_experts % WARP_SIZE == 0 || expert < n_experts) ? wt[i / WARP_SIZE] + bias[expert] : -INFINITY;
+                (n_experts % WARP_SIZE == 0 || expert < n_experts) ?
+                    wt[i / WARP_SIZE] + bias[expert] : ggml_cuda_negative_infinity();
         }
     }
 
@@ -191,7 +193,7 @@ __launch_bounds__(4 * WARP_SIZE, 1) __global__ void topk_moe_cuda(const float * 
             }
 
             if ((max_expert & (WARP_SIZE - 1)) == threadIdx.x) {
-                selection_wt[max_expert / WARP_SIZE] = -INFINITY;
+                selection_wt[max_expert / WARP_SIZE] = ggml_cuda_negative_infinity();
             }
         } else {
 #pragma unroll
@@ -214,7 +216,7 @@ __launch_bounds__(4 * WARP_SIZE, 1) __global__ void topk_moe_cuda(const float * 
             }
 
             if ((max_expert & (WARP_SIZE - 1)) == threadIdx.x) {
-                wt[max_expert / WARP_SIZE] = -INFINITY;
+                wt[max_expert / WARP_SIZE] = ggml_cuda_negative_infinity();
             }
         }
 
@@ -351,7 +353,7 @@ void ggml_cuda_op_topk_moe(ggml_backend_cuda_context &     ctx,
 
     const bool with_norm = clamp != nullptr;
 
-    float clamp_val = -INFINITY;
+    float clamp_val = 0.0f;
     if (clamp) {
         clamp_val = ggml_get_op_params_f32(clamp, 0);
     }


### PR DESCRIPTION
## Summary

Preserve exact IEEE negative-infinity sentinels in CUDA/HIP kernels without spelling them as `-INFINITY`, which ROCm 7.2 / Clang 22 rejects under `-ffast-math -Werror`.

This fixes the HIP compiler failure currently visible in the ROCm 7.2 quality build.

## Root cause

Clang 22 diagnoses builtin infinity construction as undefined under finite-math assumptions. The HIP quality build initially stops in the block-reduction sentinel in `common.cuh`. Once that first site is repaired, the same diagnostic appears in cross-entropy, DSV4, softmax, and top-k MoE kernels.

Suppressing the warning or replacing infinity with `-FLT_MAX` would be incomplete: the former retains the fast-math incompatibility, while the latter changes all-negative-infinity reduction semantics.

## Fix

- Add one device helper that constructs `-inf` from its exact IEEE-754 bit pattern via `__int_as_float(0xff800000)`.
- Use it at every executable CUDA/HIP negative-infinity sentinel site.
- Initialize the unused host-side MoE clamp launch value to `0.0f`; active clamp paths overwrite it from tensor parameters.

No kernel algorithm, launch shape, quantization format, model recipe, or runtime option changes.

## Build validation

Local Nix ROCm 7.2.2 / Clang 22.0.0:

- Offline `gfx942` quality build matching CI.
- `GGML_HIP=ON`.
- `CMAKE_HIP_FLAGS=-Werror -Wno-tautological-compare`.
- Release target with `-ffast-math`.
- `LLAMA_BUILD_WEBUI=OFF`.
- Full `ggml-hip` target: 152/152 build steps passed.
- Native `gfx1151` `llama-server` build completed successfully.

The upstream HIP-quality job also compiles the HIP backend and proceeds to 93%. Its eventual failure is the independent missing-WebUI-assets issue addressed by PR #25.

## Served runtime regression validation

The integrated Ciru branch tip containing this patch was exercised on a Radeon 8060S with ROCm 7.2.2 using Qwen3.6 35B-A3B Chadrock Ace Saber, `draft-mtp`, an uncached 8,192-token prompt, and 512 generated tokens.

Steady-state served API results:

| Quantization | Baseline runner | Patched integration runner | PP change | TG change | Total latency change |
| --- | ---: | ---: | ---: | ---: | ---: |
| ROCmFP4 STRIX_LEAN | `ef43f95` | `5d04ce3` | +2.99% | +3.61% | -3.18% |
| ROCmFPX MoEQuality 7.07 BPW | `ef43f95` | `5d04ce3` | +0.12% | +3.19% | -1.73% |

All six valid requests per quantization completed, MTP remained active, and corresponding ROCmFP4 runs had identical draft/generated acceptance counts. These measurements establish no served-runtime regression at the integrated branch tip; because that tip contains other intervening changes, they are not presented as performance attribution to this patch alone.

## Scope

This patch is independent of the WebUI stack and can be reviewed or merged separately.
