### PR TITLE
Add Buy Me a Coffee funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: [charlie12345]
+buy_me_a_coffee: rocmfpx


### PR DESCRIPTION
## Summary

- add the Buy Me a Coffee account `rocmfpx` to `.github/FUNDING.yml`
- preserve the existing GitHub Sponsors account

## Impact

GitHub can show Buy Me a Coffee alongside the existing sponsor option in the repository funding menu after this change is merged.

## Validation

- `git diff --check`
- confirmed the PR contains only `.github/FUNDING.yml`
