### PR TITLE
server: add SSD prompt cache for stateful MTP

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1358,6 +1358,28 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_env("LLAMA_ARG_CACHE_RAM").set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}));
     add_opt(common_arg(
+        {"--cache-disk"}, "PATH",
+        "base directory for the automatic SSD-backed prompt cache (default: disabled); "
+        "the server creates and removes an owner-only run directory below PATH",
+        [](common_params & params, const std::string & value) {
+            if (value.empty()) {
+                throw std::invalid_argument("cache disk path must not be empty");
+            }
+            params.cache_disk_path = value;
+        }
+    ).set_env("LLAMA_ARG_CACHE_DISK").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
+        {"--cache-disk-limit"}, "N",
+        string_format("maximum SSD-backed prompt-cache size in MiB when --cache-disk is set "
+            "(default: %d, 0 - disable)", params.cache_disk_limit_mib),
+        [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("cache disk limit must be non-negative");
+            }
+            params.cache_disk_limit_mib = value;
+        }
+    ).set_env("LLAMA_ARG_CACHE_DISK_LIMIT").set_examples({LLAMA_EXAMPLE_SERVER}));
+    add_opt(common_arg(
         {"-kvu", "--kv-unified"},
         {"-no-kvu", "--no-kv-unified"},
         "use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)",
@@ -1368,7 +1390,7 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
     add_opt(common_arg(
         {"--cache-idle-slots"},
         {"--no-cache-idle-slots"},
-        "save idle slots to the prompt cache on new task, and clear them when using unified KV (default: enabled, requires cache-ram)",
+        "save idle slots to the prompt cache on new task, and clear them when using unified KV (default: enabled, requires cache RAM or disk)",
         [](common_params & params, bool value) {
             params.cache_idle_slots = value;
         }

--- a/common/common.h
+++ b/common/common.h
@@ -610,6 +610,7 @@ struct common_params {
     int32_t n_ctx_checkpoints   = 32;    // max number of context checkpoints per slot
     int32_t checkpoint_every_nt = 8192;  // make a checkpoint every n tokens during prefill
     int32_t cache_ram_mib       = 8192;  // -1 = no limit, 0 - disable, 1 = 1 MiB, etc.
+    int32_t cache_disk_limit_mib = 8192; // disk prompt-cache limit when cache_disk_path is set
 
     std::string hostname      = "127.0.0.1";
     std::string public_path   = "";                                                                         // NOLINT
@@ -646,6 +647,10 @@ struct common_params {
 
     // enable built-in tools
     std::vector<std::string> server_tools;
+
+    // Optional base directory for the automatic SSD-backed prompt cache. The
+    // server creates and owns a private per-process directory below this path.
+    std::string cache_disk_path;
 
     // router server configs
     std::string models_dir    = ""; // directory containing models for the router server

--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -178,7 +178,9 @@ struct common_speculative_impl {
 
     // (optional) serialize/restore per-seq internal state (e.g. eagle3's deferred boundary).
     virtual bool get_state(llama_seq_id /*seq_id*/, std::vector<uint8_t> & /*data*/) const { return false; }
-    virtual void set_state(llama_seq_id /*seq_id*/, const std::vector<uint8_t> & /*data*/) {}
+    virtual bool set_state(llama_seq_id /*seq_id*/, const std::vector<uint8_t> & /*data*/) { return true; }
+    virtual bool state_required() const { return false; }
+    virtual void shift_state(llama_seq_id /*seq_id*/, llama_pos /*delta*/) {}
 
     // true if this implementation requires the target context to extract post-norm embeddings
     virtual bool need_embd() const = 0;
@@ -912,15 +914,23 @@ struct common_speculative_impl_draft_eagle3 : public common_speculative_impl {
         return true;
     }
 
-    void set_state(llama_seq_id seq_id, const std::vector<uint8_t> & data) override {
-        if (!need_boundary_stash()) {
-            return;
-        }
+    bool set_state(llama_seq_id seq_id, const std::vector<uint8_t> & data) override {
         if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq) {
-            return;
+            return false;
+        }
+        if (data.empty()) {
+            pending_pos_last[seq_id] = -1;
+            std::fill(pending_g_last[seq_id].begin(), pending_g_last[seq_id].end(), 0.0f);
+            verify_g[seq_id].clear();
+            verify_pos_first[seq_id] = -1;
+            verify_g_rows[seq_id] = 0;
+            return !need_boundary_stash();
+        }
+        if (!need_boundary_stash()) {
+            return true;
         }
         if (data.size() != sizeof(llama_pos) + (size_t) n_embd_dec * sizeof(float)) {
-            return;
+            return false;
         }
 
         llama_pos pos = -1;
@@ -929,6 +939,24 @@ struct common_speculative_impl_draft_eagle3 : public common_speculative_impl {
         pending_pos_last[seq_id] = pos;
         pending_g_last[seq_id].resize(n_embd_dec);
         std::memcpy(pending_g_last[seq_id].data(), data.data() + sizeof(llama_pos), (size_t) n_embd_dec * sizeof(float));
+        return true;
+    }
+
+    bool state_required() const override {
+        return need_boundary_stash();
+    }
+
+    void shift_state(llama_seq_id seq_id, llama_pos delta) override {
+        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq || delta == 0) {
+            return;
+        }
+
+        if (pending_pos_last[seq_id] >= 0) {
+            pending_pos_last[seq_id] += delta;
+        }
+        if (verify_pos_first[seq_id] >= 0) {
+            verify_pos_first[seq_id] += delta;
+        }
     }
 
     bool need_embd() const override {
@@ -1263,6 +1291,18 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
     // The last h-row of one process() call needs the first token of the NEXT
     // call to pair with, so it's stashed here until that next call fires.
     std::vector<std::vector<float>> pending_h;   // [n_seq][n_embd]
+    std::vector<std::vector<float>> pending_h_prev;
+    std::vector<uint8_t> pending_h_valid;
+    std::vector<uint8_t> pending_h_prev_valid;
+    std::vector<llama_pos> pending_h_pos;
+    std::vector<llama_pos> pending_h_prev_pos;
+
+    // Boundary selected for the most recent process() batch. This is needed
+    // when verification accepts row zero, and when a one-token replay advances
+    // the current boundary while retaining the prior one.
+    std::vector<std::vector<float>> process_boundary_h;
+    std::vector<uint8_t> process_boundary_valid;
+    std::vector<llama_pos> process_boundary_pos;
 
     std::vector<int32_t> i_batch_beg;
     std::vector<int32_t> i_batch_end;
@@ -1271,6 +1311,7 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
     // Row 0 corresponds to the sampled token, row N to the Nth accepted draft token.
     std::vector<std::vector<float>> verify_h;
     std::vector<int32_t> verify_h_rows;
+    std::vector<llama_pos> verify_pos_first;
 
     // Per-seq draft length from the last draft() call, used in accept() to
     // roll back ctx_dft's recurrent state past the AR draft's redundant
@@ -1356,6 +1397,15 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
         }
 
         pending_h.assign(n_seq, std::vector<float>(n_embd, 0.0f));
+        pending_h_prev.assign(n_seq, std::vector<float>(n_embd, 0.0f));
+        pending_h_valid.assign(n_seq, 0);
+        pending_h_prev_valid.assign(n_seq, 0);
+        pending_h_pos.assign(n_seq, -1);
+        pending_h_prev_pos.assign(n_seq, -1);
+
+        process_boundary_h.assign(n_seq, std::vector<float>(n_embd, 0.0f));
+        process_boundary_valid.assign(n_seq, 0);
+        process_boundary_pos.assign(n_seq, -1);
 
         i_last.assign(n_seq, -1);
         i_batch_beg.assign(n_seq, -1);
@@ -1366,6 +1416,7 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
             h.reserve((size_t) std::max<int32_t>(1, this->params.n_max) * n_embd);
         }
         verify_h_rows.assign(n_seq, 0);
+        verify_pos_first.assign(n_seq, -1);
 
         last_n_drafted.assign(n_seq, 0);
         drafting.assign(n_seq, 0);
@@ -1423,6 +1474,9 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
         std::fill(i_batch_beg.begin(), i_batch_beg.end(), -1);
         std::fill(i_batch_end.begin(), i_batch_end.end(), -1);
         std::fill(verify_h_rows.begin(), verify_h_rows.end(), 0);
+        std::fill(verify_pos_first.begin(), verify_pos_first.end(), -1);
+        std::fill(process_boundary_valid.begin(), process_boundary_valid.end(), 0);
+        std::fill(process_boundary_pos.begin(), process_boundary_pos.end(), -1);
 
         for (int k = 0; k < n_tokens; ++k) {
             GGML_ASSERT(batch_in.n_seq_id[k] == 1);
@@ -1478,7 +1532,37 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
                 continue;
             }
 
-            set_h(i_batch_beg[seq_id], pending_h[seq_id].data());
+            const llama_pos pos_needed = batch_in.pos[i_batch_beg[seq_id]] - 1;
+            const float * h_boundary = nullptr;
+            if (pending_h_valid[seq_id] && pending_h_pos[seq_id] == pos_needed) {
+                h_boundary = pending_h[seq_id].data();
+            } else if (pending_h_prev_valid[seq_id] && pending_h_prev_pos[seq_id] == pos_needed) {
+                h_boundary = pending_h_prev[seq_id].data();
+            } else if (pos_needed < 0) {
+                // A new request can reach BOS without prompt_clear(), notably
+                // through an explicit id_slot or with prompt caching disabled.
+                // Never reuse the prior request's deferred MTP boundary there.
+                std::fill(pending_h[seq_id].begin(), pending_h[seq_id].end(), 0.0f);
+                std::fill(pending_h_prev[seq_id].begin(), pending_h_prev[seq_id].end(), 0.0f);
+                pending_h_valid[seq_id] = 0;
+                pending_h_prev_valid[seq_id] = 0;
+                pending_h_pos[seq_id] = -1;
+                pending_h_prev_pos[seq_id] = -1;
+                h_boundary = pending_h[seq_id].data();
+            } else {
+                LOG_ERR("%s: missing MTP boundary for seq_id=%d pos=%d (current=%d/%d previous=%d/%d)\n",
+                        __func__, (int) seq_id, (int) pos_needed,
+                        (int) pending_h_pos[seq_id], (int) pending_h_valid[seq_id],
+                        (int) pending_h_prev_pos[seq_id], (int) pending_h_prev_valid[seq_id]);
+                return false;
+            }
+
+            set_h(i_batch_beg[seq_id], h_boundary);
+            if (pos_needed >= 0) {
+                std::memcpy(process_boundary_h[seq_id].data(), h_boundary, row_bytes);
+                process_boundary_valid[seq_id] = 1;
+                process_boundary_pos[seq_id] = pos_needed;
+            }
         }
 
         auto * mem_dft = llama_get_memory(ctx_dft);
@@ -1523,13 +1607,33 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
 
             const int32_t n_rows = i_batch_end[seq_id] - i_batch_beg[seq_id] + 1;
             const float * h_seq = h_tgt + (size_t) i_batch_beg[seq_id] * n_embd;
+            const llama_pos pos_last = batch_in.pos[i_batch_end[seq_id]];
+
+            if (n_rows > 1) {
+                const float * h_prev = h_seq + (size_t) (n_rows - 2) * n_embd;
+                std::memcpy(pending_h_prev[seq_id].data(), h_prev, row_bytes);
+                pending_h_prev_valid[seq_id] = 1;
+                pending_h_prev_pos[seq_id] = batch_in.pos[i_batch_end[seq_id] - 1];
+            } else if (process_boundary_valid[seq_id]) {
+                std::memcpy(pending_h_prev[seq_id].data(), process_boundary_h[seq_id].data(), row_bytes);
+                pending_h_prev_valid[seq_id] = 1;
+                pending_h_prev_pos[seq_id] = process_boundary_pos[seq_id];
+            } else {
+                std::fill(pending_h_prev[seq_id].begin(), pending_h_prev[seq_id].end(), 0.0f);
+                pending_h_prev_valid[seq_id] = 0;
+                pending_h_prev_pos[seq_id] = -1;
+            }
+
             if (last_n_drafted[seq_id] == 0) {
                 const float * h_last = h_seq + (size_t) (n_rows - 1) * n_embd;
                 std::memcpy(pending_h[seq_id].data(), h_last, row_bytes);
+                pending_h_valid[seq_id] = 1;
+                pending_h_pos[seq_id] = pos_last;
                 continue;
             }
 
             verify_h_rows[seq_id] = n_rows;
+            verify_pos_first[seq_id] = batch_in.pos[i_batch_beg[seq_id]];
             const size_t n_verify_floats = (size_t) (n_rows - 1) * n_embd;
             if (verify_h[seq_id].size() < n_verify_floats) {
                 verify_h[seq_id].resize(n_verify_floats);
@@ -1540,6 +1644,8 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
 
             const float * h_last = h_seq + (size_t) (n_rows - 1) * n_embd;
             std::memcpy(pending_h[seq_id].data(), h_last, row_bytes);
+            pending_h_valid[seq_id] = 1;
+            pending_h_pos[seq_id] = pos_last;
         }
 
         return true;
@@ -1564,6 +1670,15 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
             }
 
             last_n_drafted[seq_id] = 0;
+
+            const llama_pos pos_needed = dp.n_past - 1;
+            if (!pending_h_valid[seq_id] || pending_h_pos[seq_id] != pos_needed) {
+                LOG_WRN("%s: disabling MTP draft for seq_id=%d: boundary pos=%d/%d, needed=%d\n",
+                        __func__, (int) seq_id, (int) pending_h_pos[seq_id],
+                        (int) pending_h_valid[seq_id], (int) pos_needed);
+                dp.drafting = false;
+                continue;
+            }
 
             n_drafting++;
             drafting[seq_id] = 1;
@@ -1724,11 +1839,149 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
         }
 
         const int32_t i_h = std::min<int32_t>(n_accepted, n_rows - 1);
+        const size_t row_bytes = (size_t) n_embd * sizeof(float);
         if (i_h != n_rows - 1) {
-            const size_t row_bytes = (size_t) n_embd * sizeof(float);
             std::memcpy(pending_h[seq_id].data(), verify_h[seq_id].data() + (size_t) i_h * n_embd, row_bytes);
         }
+        pending_h_valid[seq_id] = 1;
+        pending_h_pos[seq_id] = verify_pos_first[seq_id] + i_h;
+
+        if (i_h == 0) {
+            if (process_boundary_valid[seq_id]) {
+                std::memcpy(pending_h_prev[seq_id].data(), process_boundary_h[seq_id].data(), row_bytes);
+                pending_h_prev_valid[seq_id] = 1;
+                pending_h_prev_pos[seq_id] = process_boundary_pos[seq_id];
+            } else {
+                std::fill(pending_h_prev[seq_id].begin(), pending_h_prev[seq_id].end(), 0.0f);
+                pending_h_prev_valid[seq_id] = 0;
+                pending_h_prev_pos[seq_id] = -1;
+            }
+        } else {
+            std::memcpy(pending_h_prev[seq_id].data(), verify_h[seq_id].data() + (size_t) (i_h - 1) * n_embd, row_bytes);
+            pending_h_prev_valid[seq_id] = 1;
+            pending_h_prev_pos[seq_id] = verify_pos_first[seq_id] + i_h - 1;
+        }
         last_n_drafted[seq_id] = 0;
+    }
+
+    static constexpr uint32_t MTP_STATE_MAGIC       = 0x3250544d; // "MTP2" in little-endian byte order
+    static constexpr uint16_t MTP_STATE_VERSION     = 2;
+    static constexpr uint16_t MTP_STATE_CURRENT     = 1u << 0;
+    static constexpr uint16_t MTP_STATE_PREVIOUS    = 1u << 1;
+    static constexpr size_t   MTP_STATE_HEADER      = sizeof(uint32_t) + 2*sizeof(uint16_t) + sizeof(uint32_t) + 2*sizeof(llama_pos);
+
+    void reset_seq_state(llama_seq_id seq_id) {
+        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq) {
+            return;
+        }
+
+        std::fill(pending_h[seq_id].begin(), pending_h[seq_id].end(), 0.0f);
+        std::fill(pending_h_prev[seq_id].begin(), pending_h_prev[seq_id].end(), 0.0f);
+        pending_h_valid[seq_id] = 0;
+        pending_h_prev_valid[seq_id] = 0;
+        pending_h_pos[seq_id] = -1;
+        pending_h_prev_pos[seq_id] = -1;
+        std::fill(process_boundary_h[seq_id].begin(), process_boundary_h[seq_id].end(), 0.0f);
+        process_boundary_valid[seq_id] = 0;
+        process_boundary_pos[seq_id] = -1;
+        verify_h[seq_id].clear();
+        verify_h_rows[seq_id] = 0;
+        verify_pos_first[seq_id] = -1;
+        last_n_drafted[seq_id] = 0;
+        drafting[seq_id] = 0;
+        i_last[seq_id] = -1;
+        if (chain_heads) {
+            chain_h[seq_id].clear();
+        }
+    }
+
+    bool get_state(llama_seq_id seq_id, std::vector<uint8_t> & data) const override {
+        data.clear();
+        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq || !pending_h_valid[seq_id]) {
+            return false;
+        }
+
+        const uint16_t flags = MTP_STATE_CURRENT |
+            (pending_h_prev_valid[seq_id] ? MTP_STATE_PREVIOUS : 0);
+        const uint32_t width = (uint32_t) n_embd;
+        const size_t row_bytes = (size_t) n_embd * sizeof(float);
+        data.resize(MTP_STATE_HEADER + 2*row_bytes);
+
+        size_t off = 0;
+        std::memcpy(data.data() + off, &MTP_STATE_MAGIC,   sizeof(MTP_STATE_MAGIC));   off += sizeof(MTP_STATE_MAGIC);
+        std::memcpy(data.data() + off, &MTP_STATE_VERSION, sizeof(MTP_STATE_VERSION)); off += sizeof(MTP_STATE_VERSION);
+        std::memcpy(data.data() + off, &flags,             sizeof(flags));             off += sizeof(flags);
+        std::memcpy(data.data() + off, &width,             sizeof(width));             off += sizeof(width);
+        std::memcpy(data.data() + off, &pending_h_pos[seq_id],      sizeof(llama_pos)); off += sizeof(llama_pos);
+        std::memcpy(data.data() + off, &pending_h_prev_pos[seq_id], sizeof(llama_pos)); off += sizeof(llama_pos);
+        std::memcpy(data.data() + off, pending_h[seq_id].data(), row_bytes); off += row_bytes;
+        std::memcpy(data.data() + off, pending_h_prev[seq_id].data(), row_bytes);
+        return true;
+    }
+
+    bool set_state(llama_seq_id seq_id, const std::vector<uint8_t> & data) override {
+        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq) {
+            return false;
+        }
+
+        reset_seq_state(seq_id);
+        if (data.empty() || data.size() < MTP_STATE_HEADER) {
+            return false;
+        }
+
+        uint32_t magic = 0;
+        uint16_t version = 0;
+        uint16_t flags = 0;
+        uint32_t width = 0;
+        llama_pos pos_current = -1;
+        llama_pos pos_previous = -1;
+        size_t off = 0;
+        std::memcpy(&magic,   data.data() + off, sizeof(magic));   off += sizeof(magic);
+        std::memcpy(&version, data.data() + off, sizeof(version)); off += sizeof(version);
+        std::memcpy(&flags,   data.data() + off, sizeof(flags));   off += sizeof(flags);
+        std::memcpy(&width,   data.data() + off, sizeof(width));   off += sizeof(width);
+        std::memcpy(&pos_current,  data.data() + off, sizeof(pos_current));  off += sizeof(pos_current);
+        std::memcpy(&pos_previous, data.data() + off, sizeof(pos_previous)); off += sizeof(pos_previous);
+
+        const size_t row_bytes = (size_t) n_embd * sizeof(float);
+        if (magic != MTP_STATE_MAGIC || version != MTP_STATE_VERSION ||
+            (flags & MTP_STATE_CURRENT) == 0 || (flags & ~(MTP_STATE_CURRENT | MTP_STATE_PREVIOUS)) != 0 ||
+            width != (uint32_t) n_embd || pos_current < 0 ||
+            ((flags & MTP_STATE_PREVIOUS) != 0 && pos_previous < 0) ||
+            data.size() != MTP_STATE_HEADER + 2*row_bytes) {
+            return false;
+        }
+
+        std::memcpy(pending_h[seq_id].data(), data.data() + off, row_bytes); off += row_bytes;
+        std::memcpy(pending_h_prev[seq_id].data(), data.data() + off, row_bytes);
+        pending_h_valid[seq_id] = 1;
+        pending_h_prev_valid[seq_id] = (flags & MTP_STATE_PREVIOUS) != 0;
+        pending_h_pos[seq_id] = pos_current;
+        pending_h_prev_pos[seq_id] = pending_h_prev_valid[seq_id] ? pos_previous : -1;
+        return true;
+    }
+
+    bool state_required() const override {
+        return true;
+    }
+
+    void shift_state(llama_seq_id seq_id, llama_pos delta) override {
+        if (seq_id < 0 || seq_id >= (llama_seq_id) n_seq || delta == 0) {
+            return;
+        }
+
+        if (pending_h_valid[seq_id]) {
+            pending_h_pos[seq_id] += delta;
+        }
+        if (pending_h_prev_valid[seq_id]) {
+            pending_h_prev_pos[seq_id] += delta;
+        }
+        if (process_boundary_valid[seq_id]) {
+            process_boundary_pos[seq_id] += delta;
+        }
+        if (verify_h_rows[seq_id] > 0 && verify_pos_first[seq_id] >= 0) {
+            verify_pos_first[seq_id] += delta;
+        }
     }
 
     bool need_embd() const override {
@@ -2610,13 +2863,45 @@ bool common_speculative_get_state(common_speculative * spec, llama_seq_id seq_id
     return false;
 }
 
-void common_speculative_set_state(common_speculative * spec, llama_seq_id seq_id, const std::vector<uint8_t> & data) {
+bool common_speculative_set_state(common_speculative * spec, llama_seq_id seq_id, const std::vector<uint8_t> & data) {
     if (spec == nullptr) {
+        return true;
+    }
+
+    bool ok = true;
+    for (auto & impl : spec->impls) {
+        const bool restored = impl->set_state(seq_id, data);
+        ok = ok && (!impl->state_required() || restored);
+    }
+
+    if (seq_id >= 0 && seq_id < (llama_seq_id) spec->dparams.size()) {
+        spec->dparams[seq_id].drafting = false;
+    }
+
+    return ok;
+}
+
+bool common_speculative_state_required(const common_speculative * spec) {
+    if (spec == nullptr) {
+        return false;
+    }
+
+    for (const auto & impl : spec->impls) {
+        if (impl->state_required()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void common_speculative_shift_state(common_speculative * spec, llama_seq_id seq_id, llama_pos delta) {
+    if (spec == nullptr || delta == 0) {
         return;
     }
 
     for (auto & impl : spec->impls) {
-        impl->set_state(seq_id, data);
+        impl->shift_state(seq_id, delta);
     }
 }
 

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -70,7 +70,11 @@ void common_speculative_accept(common_speculative * spec, llama_seq_id, uint16_t
 
 // (optional) get/set internal state
 bool common_speculative_get_state(common_speculative * spec, llama_seq_id seq_id, std::vector<uint8_t> & data);
-void common_speculative_set_state(common_speculative * spec, llama_seq_id seq_id, const std::vector<uint8_t> & data);
+bool common_speculative_set_state(common_speculative * spec, llama_seq_id seq_id, const std::vector<uint8_t> & data);
+bool common_speculative_state_required(const common_speculative * spec);
+
+// rebase per-sequence positions after the corresponding target/draft contexts shift
+void common_speculative_shift_state(common_speculative * spec, llama_seq_id seq_id, llama_pos delta);
 
 // print statistics about the speculative decoding
 void common_speculative_print_stats(const common_speculative * spec);

--- a/tools/server/README.md
+++ b/tools/server/README.md
@@ -166,8 +166,10 @@ For the full list of features, please refer to [server's changelog](https://gith
 | `-ctxcp, --ctx-checkpoints, --swa-checkpoints N` | max number of context checkpoints to create per slot (default: 32)[(more info)](https://github.com/ggml-org/llama.cpp/pull/15293)<br/>(env: LLAMA_ARG_CTX_CHECKPOINTS) |
 | `-cpent, --checkpoint-every-n-tokens N` | create a checkpoint every n tokens during prefill (processing), -1 to disable (default: 8192)<br/>(env: LLAMA_ARG_CHECKPOINT_EVERY_NT) |
 | `-cram, --cache-ram N` | set the maximum cache size in MiB (default: 8192, -1 - no limit, 0 - disable)[(more info)](https://github.com/ggml-org/llama.cpp/pull/16391)<br/>(env: LLAMA_ARG_CACHE_RAM) |
+| `--cache-disk PATH` | base directory for the automatic SSD-backed prompt cache (default: disabled); target and MTP draft states are streamed to an owner-only per-server run directory and removed at shutdown<br/>(env: LLAMA_ARG_CACHE_DISK) |
+| `--cache-disk-limit N` | maximum SSD-backed prompt-cache size in MiB when `--cache-disk` is set (default: 8192, 0 - disable)<br/>(env: LLAMA_ARG_CACHE_DISK_LIMIT) |
 | `-kvu, --kv-unified, -no-kvu, --no-kv-unified` | use single unified KV buffer shared across all sequences (default: enabled if number of slots is auto)<br/>(env: LLAMA_ARG_KV_UNIFIED) |
-| `--cache-idle-slots, --no-cache-idle-slots` | save idle slots to the prompt cache on new task, and clear them when using unified KV (default: enabled, requires cache-ram)<br/>(env: LLAMA_ARG_CACHE_IDLE_SLOTS) |
+| `--cache-idle-slots, --no-cache-idle-slots` | save idle slots to the prompt cache on new task, and clear them when using unified KV (default: enabled, requires cache RAM or disk)<br/>(env: LLAMA_ARG_CACHE_IDLE_SLOTS) |
 | `--context-shift, --no-context-shift` | whether to use context shift on infinite text generation (default: disabled)<br/>(env: LLAMA_ARG_CONTEXT_SHIFT) |
 | `-r, --reverse-prompt PROMPT` | halt generation at PROMPT, return control in interactive mode |
 | `-sp, --special` | special tokens output enabled (default: false) |

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -128,21 +128,41 @@ struct server_slot {
         SRV_WRN(" - saving prompt with length %d, total state size = %.3f MiB (draft: %.3f MiB)\n",
                 (int) prompt.tokens.size(), cur_size / (1024.0 * 1024.0), cur_size_dft / (1024.0 * 1024.0));
 
-        auto * cur = prompt_cache.alloc(prompt, cur_size_tgt, cur_size_dft);
-        if (cur == nullptr) {
+        std::vector<uint8_t> state_spec;
+        const bool spec_state_required = common_speculative_state_required(spec);
+        const bool have_spec_state = common_speculative_get_state(spec, id, state_spec);
+        if (spec_state_required && !have_spec_state) {
+            SLT_WRN(*this, "%s", "skipping prompt cache save: required speculative state is unavailable\n");
             return false;
         }
 
-        llama_state_seq_get_data_ext(ctx_tgt, cur->data.main.data(), cur_size_tgt, id, LLAMA_STATE_SEQ_FLAGS_NONE);
-        if (ctx_dft) {
-            llama_state_seq_get_data_ext(ctx_dft, cur->data.drft.data(), cur_size_dft, id, LLAMA_STATE_SEQ_FLAGS_NONE);
-        }
-
-        return true;
+        return prompt_cache.save(prompt, ctx_tgt, ctx_dft, id, state_spec);
     }
 
     bool prompt_load(server_prompt_cache & prompt_cache, const server_tokens & tokens) {
-        bool res = prompt_cache.load(prompt, tokens, ctx_tgt, ctx_dft, id);
+        const bool spec_state_required = common_speculative_state_required(spec);
+        bool cache_hit = false;
+        uint64_t disk_entry_id = 0;
+        bool res = prompt_cache.load(prompt, tokens, ctx_tgt, ctx_dft, id, spec_state_required, &cache_hit, &disk_entry_id);
+        if (res && cache_hit) {
+            if (spec_state_required && prompt.data.spec.empty()) {
+                SLT_WRN(*this, "%s", "failed to load required speculative state from prompt cache\n");
+                res = false;
+            } else if (!prompt.data.spec.empty() && !common_speculative_set_state(spec, id, prompt.data.spec)) {
+                SLT_WRN(*this, "%s", "failed to validate speculative state from prompt cache\n");
+                res = false;
+            }
+
+            prompt.data.spec.clear();
+            prompt.data.spec.shrink_to_fit();
+        }
+        if (disk_entry_id != 0) {
+            if (res) {
+                prompt_cache.accept_disk_load(disk_entry_id);
+            } else {
+                prompt_cache.reject_disk_load(disk_entry_id, "spec-state-rejected");
+            }
+        }
         if (!res) {
             SLT_WRN(*this, "%s", "failed to load prompt from cache\n");
         }
@@ -161,6 +181,7 @@ struct server_slot {
         if (ctx_dft) {
             common_context_seq_rm(ctx_dft, id, -1, -1);
         }
+        common_speculative_set_state(spec, id, {});
 
         prompt.tokens.clear();
     }
@@ -1008,17 +1029,29 @@ private:
             batch = llama_batch_init(std::max(n_batch, params_base.n_parallel), 0, 1);
         }
 
-        if (params_base.cache_ram_mib != 0) {
-            if (params_base.cache_ram_mib < 0) {
-                SRV_INF("prompt cache is enabled, size limit: %s\n", "no limit");
-            } else {
-                SRV_INF("prompt cache is enabled, size limit: %d MiB\n", params_base.cache_ram_mib);
-            }
-            SRV_INF("%s", "use `--cache-ram 0` to disable the prompt cache\n");
+        const bool cache_disk_enabled = !params_base.cache_disk_path.empty() && params_base.cache_disk_limit_mib > 0;
 
-            prompt_cache = std::make_unique<server_prompt_cache>(params_base.cache_ram_mib, n_ctx);
+        if (params_base.cache_ram_mib != 0 || cache_disk_enabled) {
+            if (params_base.cache_ram_mib < 0) {
+                SRV_INF("prompt cache RAM enabled: limit=%s\n", "unlimited");
+            } else if (params_base.cache_ram_mib > 0) {
+                SRV_INF("prompt cache RAM enabled: limit_mib=%d\n", params_base.cache_ram_mib);
+            } else {
+                SRV_INF("%s", "prompt cache RAM disabled: limit_mib=0\n");
+            }
+
+            if (cache_disk_enabled) {
+                SRV_INF("prompt cache SSD enabled: path=%s limit_mib=%d target_and_draft=true\n",
+                        params_base.cache_disk_path.c_str(), params_base.cache_disk_limit_mib);
+            }
+
+            prompt_cache = std::make_unique<server_prompt_cache>(
+                params_base.cache_ram_mib,
+                n_ctx,
+                params_base.cache_disk_path,
+                params_base.cache_disk_limit_mib);
         } else {
-            SRV_INF("%s", "prompt cache is disabled - use `--cache-ram N` to enable it\n");
+            SRV_INF("%s", "prompt cache is disabled - use `--cache-ram N` or `--cache-disk PATH` to enable it\n");
         }
         SRV_INF("%s", "for more info see https://github.com/ggml-org/llama.cpp/pull/16391\n");
 
@@ -1067,8 +1100,8 @@ private:
         metrics.init();
 
         if (params_base.cache_idle_slots) {
-            if (params_base.cache_ram_mib == 0) {
-                SRV_WRN("%s", "--cache-idle-slots requires --cache-ram, disabling\n");
+            if (!prompt_cache) {
+                SRV_WRN("%s", "--cache-idle-slots requires --cache-ram or --cache-disk, disabling\n");
                 params_base.cache_idle_slots = false;
             } else {
                 if (params_base.kv_unified) {
@@ -1235,6 +1268,8 @@ private:
 
                 if (!ret->prompt_load(*prompt_cache, task.tokens)) {
                     ret->prompt_clear(false);
+                    SRV_INF("prompt cache cold fallback: slot=%d reason=target-draft-restore-rejected target_and_draft_cleared=true\n",
+                            ret->id);
                 }
 
                 prompt_cache->update();
@@ -1983,14 +2018,17 @@ private:
                             if (!slot.is_processing()) {
                                 SLT_INF(slot, "%s", "saving idle slot to prompt cache\n");
 
-                                if (slot.prompt_save(*prompt_cache)) {
+                                const bool safe_to_clear = slot.prompt_save(*prompt_cache);
+                                if (safe_to_clear) {
                                     SLT_DBG(slot, "%s", "__TEST_TAG_CACHE_IDLE_SLOT__\n");
                                     prompt_cache->update();
-                                }
 
-                                if (params_base.kv_unified) {
-                                    // [TAG_IDLE_SLOT_CLEAR]
-                                    slot.prompt_clear(false);
+                                    if (params_base.kv_unified) {
+                                        // [TAG_IDLE_SLOT_CLEAR]
+                                        slot.prompt_clear(false);
+                                    }
+                                } else if (!slot.prompt.tokens.empty()) {
+                                    SLT_WRN(slot, "%s", "preserving idle slot because prompt cache save was not safe\n");
                                 }
                             }
                         }
@@ -2286,6 +2324,8 @@ private:
                     common_context_seq_rm (ctx_dft.get(), slot.id, n_keep            , n_keep + n_discard);
                     common_context_seq_add(ctx_dft.get(), slot.id, n_keep + n_discard, slot.prompt.tokens.pos_next(), -n_discard);
                 }
+
+                common_speculative_shift_state(spec.get(), slot.id, -n_discard);
 
                 // add generated tokens to cache
                 // ref: https://github.com/ggml-org/llama.cpp/pull/16818#discussion_r2473269481
@@ -2631,6 +2671,20 @@ private:
                             } else {
                                 // if we don't cache the prompt, we have to remove all previous tokens
                                 n_past = 0;
+                            }
+
+                            // MTP carries only the endpoint and immediately preceding target hidden
+                            // boundaries. Arbitrary partial-prefix rollback cannot be reconstructed
+                            // from target/draft KV state, so reprocess cold instead of pairing a token
+                            // with the wrong hidden row. Full-prefix extension and the exact-hit
+                            // one-token replay below remain supported.
+                            if (common_speculative_state_required(spec.get()) &&
+                                n_past > 0 && n_past < slot.prompt.n_tokens()) {
+                                SLT_INF(slot,
+                                        "prompt cache cold fallback: reason=spec-boundary-mismatch lcp=%d cached_tokens=%d request_tokens=%d\n",
+                                        n_past, slot.prompt.n_tokens(), slot.task->n_tokens());
+                                n_past = 0;
+                                common_speculative_set_state(spec.get(), slot.id, {});
                             }
 
                             llama_pos pos_next = slot.prompt.tokens.pos_next(n_past);

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -2047,9 +2047,16 @@ static bool server_prompt_cache_disk_flush_and_drop(const std::string & path, bo
     }
 
     bool ok = true;
-    if (durable && fdatasync(fd) != 0) {
-        SRV_ERR("prompt cache disk fdatasync failed: path=%s error=%s\n", path.c_str(), std::strerror(errno));
-        ok = false;
+    if (durable) {
+#if defined(__APPLE__)
+        const int sync_result = fsync(fd);
+#else
+        const int sync_result = fdatasync(fd);
+#endif
+        if (sync_result != 0) {
+            SRV_ERR("prompt cache disk file sync failed: path=%s error=%s\n", path.c_str(), std::strerror(errno));
+            ok = false;
+        }
     }
 
 #if defined(POSIX_FADV_DONTNEED)

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -10,6 +10,22 @@
 #include "speculative.h"
 #include "server-common.h"
 
+#include <cerrno>
+#include <cinttypes>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <limits>
+#include <system_error>
+
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+#endif
+
 using json = nlohmann::ordered_json;
 
 //
@@ -1962,6 +1978,319 @@ json server_task_result_apply_lora::to_json() {
 //
 // server_prompt_cache
 //
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr const char * SERVER_PROMPT_CACHE_DISK_NAMESPACE = ".llama-prompt-cache-v1";
+constexpr const char * SERVER_PROMPT_CACHE_OWNER_MAGIC = "llama.cpp automatic prompt cache v1";
+
+static bool server_prompt_cache_disk_owned(const fs::path & path) {
+    std::ifstream owner(path / ".owner");
+    std::string magic;
+    return owner.good() && std::getline(owner, magic) && magic == SERVER_PROMPT_CACHE_OWNER_MAGIC;
+}
+
+static bool server_prompt_cache_disk_remove_file(const std::string & path) {
+    if (path.empty()) {
+        return true;
+    }
+
+    std::error_code ec;
+    fs::remove(path, ec);
+    if (ec) {
+        SRV_WRN("prompt cache disk cleanup failed: path=%s error=%s\n", path.c_str(), ec.message().c_str());
+        return false;
+    }
+
+    // A missing file already satisfies the desired postcondition. This also
+    // lets a later retry finish a pair after an earlier partial removal.
+    return true;
+}
+
+static bool server_prompt_cache_disk_size_exact(
+        const std::string & path,
+                    size_t expected,
+                    size_t * actual_out = nullptr) {
+    if (path.empty()) {
+        if (actual_out != nullptr) {
+            *actual_out = 0;
+        }
+        return expected == 0;
+    }
+
+    std::error_code ec;
+    const uintmax_t actual = fs::file_size(path, ec);
+    if (ec || actual > std::numeric_limits<size_t>::max()) {
+        if (actual_out != nullptr) {
+            *actual_out = 0;
+        }
+        return false;
+    }
+
+    if (actual_out != nullptr) {
+        *actual_out = (size_t) actual;
+    }
+    return (size_t) actual == expected;
+}
+
+// llama_state_seq_save_file() closes the file before returning. Reopen it to
+// force dirty pages to stable storage and immediately mark the cold state as
+// reclaimable. This avoids replacing anonymous cache pressure with several GiB
+// of sticky buffered page cache on UMA systems.
+static bool server_prompt_cache_disk_flush_and_drop(const std::string & path, bool durable) {
+#if !defined(_WIN32)
+    const int fd = open(path.c_str(), (durable ? O_RDWR : O_RDONLY) | O_CLOEXEC);
+    if (fd < 0) {
+        SRV_ERR("prompt cache disk open failed: path=%s error=%s\n", path.c_str(), std::strerror(errno));
+        return false;
+    }
+
+    bool ok = true;
+    if (durable && fdatasync(fd) != 0) {
+        SRV_ERR("prompt cache disk fdatasync failed: path=%s error=%s\n", path.c_str(), std::strerror(errno));
+        ok = false;
+    }
+
+#if defined(POSIX_FADV_DONTNEED)
+    const int err = posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+    if (err != 0) {
+        SRV_WRN("prompt cache disk fadvise failed: path=%s error=%s\n", path.c_str(), std::strerror(err));
+    }
+#endif
+
+    close(fd);
+    return ok;
+#else
+    GGML_UNUSED(path);
+    GGML_UNUSED(durable);
+    return true;
+#endif
+}
+
+static bool server_prompt_cache_disk_sync_dir(const std::string & path) {
+#if !defined(_WIN32)
+    const int fd = open(path.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    if (fd < 0) {
+        SRV_ERR("prompt cache disk directory open failed: path=%s error=%s\n", path.c_str(), std::strerror(errno));
+        return false;
+    }
+
+    const bool ok = fsync(fd) == 0;
+    if (!ok) {
+        SRV_ERR("prompt cache disk directory fsync failed: path=%s error=%s\n", path.c_str(), std::strerror(errno));
+    }
+    close(fd);
+    return ok;
+#else
+    GGML_UNUSED(path);
+    return true;
+#endif
+}
+
+static bool server_prompt_cache_tokens_equal(const server_tokens & expected, const llama_tokens & actual) {
+    return expected.get_tokens() == actual;
+}
+
+} // namespace
+
+server_prompt_cache::server_prompt_cache(
+        int32_t limit_size_mib,
+         size_t limit_tokens,
+    const std::string & disk_base_path,
+        int32_t disk_limit_size_mib) {
+    ram_enabled       = limit_size_mib != 0;
+    limit_size        = 1024ull*1024ull*(limit_size_mib < 0 ? 0 : limit_size_mib);
+    this->limit_tokens = limit_tokens;
+
+    if (disk_base_path.empty() || disk_limit_size_mib <= 0) {
+        return;
+    }
+
+    disk_limit_size = 1024ull*1024ull*disk_limit_size_mib;
+
+    std::error_code ec;
+    fs::path base = fs::absolute(disk_base_path, ec);
+    if (ec) {
+        throw std::runtime_error("unable to resolve prompt cache disk path '" + disk_base_path + "': " + ec.message());
+    }
+
+    fs::create_directories(base, ec);
+    if (ec || !fs::is_directory(base)) {
+        throw std::runtime_error("unable to create prompt cache disk path '" + base.string() + "': " + ec.message());
+    }
+
+    const fs::path cache_root = base / SERVER_PROMPT_CACHE_DISK_NAMESPACE;
+    fs::create_directories(cache_root, ec);
+    if (ec || !fs::is_directory(cache_root)) {
+        throw std::runtime_error("unable to create prompt cache namespace '" + cache_root.string() + "': " + ec.message());
+    }
+    fs::permissions(cache_root, fs::perms::owner_all, fs::perm_options::replace, ec);
+    if (ec) {
+        throw std::runtime_error("unable to secure prompt cache namespace '" + cache_root.string() + "': " + ec.message());
+    }
+
+    // An OOM/SIGKILL cannot run the destructor. Each run therefore holds an
+    // advisory lock in a magic-marked directory. A later server removes only
+    // marked run-* directories whose lock is no longer held.
+    for (const auto & entry : fs::directory_iterator(cache_root, ec)) {
+        if (ec) {
+            break;
+        }
+        const auto name = entry.path().filename().string();
+        const bool is_run_dir      = name.rfind("run-", 0) == 0;
+        const bool is_deleting_dir = name.rfind(".deleting-run-", 0) == 0;
+        if (!entry.is_directory() || (!is_run_dir && !is_deleting_dir) || !server_prompt_cache_disk_owned(entry.path())) {
+            continue;
+        }
+
+#if !defined(_WIN32)
+        const fs::path lock_path = entry.path() / ".lock";
+        const int fd = open(lock_path.c_str(), O_RDWR | O_CLOEXEC);
+        if (fd < 0) {
+            continue;
+        }
+        const bool stale = flock(fd, LOCK_EX | LOCK_NB) == 0;
+        if (stale) {
+            flock(fd, LOCK_UN);
+        }
+        close(fd);
+        if (!stale) {
+            continue;
+        }
+#else
+        // Without an advisory-lock primitive, preserve old directories rather
+        // than risk deleting a live cache owned by another process.
+        continue;
+#endif
+
+        const auto stale_path = entry.path().string();
+        std::error_code rm_ec;
+        const auto removed = fs::remove_all(entry.path(), rm_ec);
+        if (!rm_ec) {
+            SRV_INF("prompt cache disk stale cleanup: path=%s files=%zu\n", stale_path.c_str(), (size_t) removed);
+        }
+    }
+
+    const auto stamp = (uint64_t) std::chrono::high_resolution_clock::now().time_since_epoch().count();
+#if !defined(_WIN32)
+    const auto pid = (uint64_t) getpid();
+#else
+    const uint64_t pid = 0;
+#endif
+
+    fs::path owned;
+    for (uint32_t suffix = 0; suffix < 1000; ++suffix) {
+        owned = cache_root / ("run-" + std::to_string(pid) + "-" + std::to_string(stamp) + "-" + std::to_string(suffix));
+        if (fs::create_directory(owned, ec)) {
+            break;
+        }
+        if (ec && ec != std::errc::file_exists) {
+            throw std::runtime_error("unable to create owned prompt cache directory '" + owned.string() + "': " + ec.message());
+        }
+        ec.clear();
+        owned.clear();
+    }
+    if (owned.empty() || !fs::is_directory(owned)) {
+        throw std::runtime_error("unable to allocate a unique prompt cache run directory below '" + cache_root.string() + "'");
+    }
+
+    fs::permissions(owned, fs::perms::owner_all, fs::perm_options::replace, ec);
+    if (ec) {
+        fs::remove_all(owned);
+        throw std::runtime_error("unable to secure owned prompt cache directory '" + owned.string() + "': " + ec.message());
+    }
+
+#if !defined(_WIN32)
+    // Publish and hold the lock before publishing .owner. Stale cleanup only
+    // considers magic-marked directories, so another startup can never see an
+    // owned directory in the window before this process has acquired its lock.
+    const fs::path lock_path = owned / ".lock";
+    disk_lock_fd = open(lock_path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC, 0600);
+    if (disk_lock_fd < 0 || flock(disk_lock_fd, LOCK_EX | LOCK_NB) != 0) {
+        if (disk_lock_fd >= 0) {
+            close(disk_lock_fd);
+            disk_lock_fd = -1;
+        }
+        fs::remove_all(owned);
+        throw std::runtime_error("unable to lock owned prompt cache directory '" + owned.string() + "'");
+    }
+#else
+    {
+        std::ofstream lock(owned / ".lock", std::ios::out | std::ios::trunc);
+        if (!lock.good()) {
+            fs::remove_all(owned);
+            throw std::runtime_error("unable to create prompt cache lock file in '" + owned.string() + "'");
+        }
+    }
+#endif
+
+    {
+        std::ofstream owner(owned / ".owner", std::ios::out | std::ios::trunc);
+        owner << SERVER_PROMPT_CACHE_OWNER_MAGIC << '\n'
+              << "pid=" << pid << '\n'
+              << "created=" << stamp << '\n';
+        owner.flush();
+        if (!owner.good()) {
+#if !defined(_WIN32)
+            flock(disk_lock_fd, LOCK_UN);
+            close(disk_lock_fd);
+            disk_lock_fd = -1;
+#endif
+            fs::remove_all(owned);
+            throw std::runtime_error("unable to write prompt cache ownership manifest in '" + owned.string() + "'");
+        }
+    }
+    fs::permissions(owned / ".owner", fs::perms::owner_read | fs::perms::owner_write, fs::perm_options::replace, ec);
+    if (ec) {
+#if !defined(_WIN32)
+        flock(disk_lock_fd, LOCK_UN);
+        close(disk_lock_fd);
+        disk_lock_fd = -1;
+#endif
+        fs::remove_all(owned);
+        throw std::runtime_error("unable to secure prompt cache ownership manifest in '" + owned.string() + "': " + ec.message());
+    }
+
+    this->disk_base_path  = base.string();
+    this->disk_owned_path = owned.string();
+
+    SRV_INF("prompt cache disk enabled: path=%s owned_path=%s limit_mib=%d\n",
+            this->disk_base_path.c_str(), this->disk_owned_path.c_str(), disk_limit_size_mib);
+}
+
+server_prompt_cache::~server_prompt_cache() {
+    if (disk_owned_path.empty()) {
+        return;
+    }
+
+    SRV_INF("prompt cache disk cleanup: path=%s entries=%zu bytes=%zu saves=%" PRIu64 " loads=%" PRIu64 " evictions=%" PRIu64 "\n",
+            disk_owned_path.c_str(), disk_states.size(), disk_size_total, disk_saves, disk_loads, disk_evictions);
+
+    fs::path cleanup_path = disk_owned_path;
+    std::error_code ec;
+    const fs::path trash_path = cleanup_path.parent_path() / (".deleting-" + cleanup_path.filename().string());
+    fs::rename(cleanup_path, trash_path, ec);
+    if (!ec) {
+        cleanup_path = trash_path;
+    } else {
+        ec.clear();
+    }
+
+#if !defined(_WIN32)
+    if (disk_lock_fd >= 0) {
+        flock(disk_lock_fd, LOCK_UN);
+        close(disk_lock_fd);
+        disk_lock_fd = -1;
+    }
+#endif
+
+    fs::remove_all(cleanup_path, ec);
+    if (ec) {
+        SRV_WRN("prompt cache disk cleanup failed: path=%s error=%s\n", cleanup_path.string().c_str(), ec.message().c_str());
+    }
+}
+
 size_t server_prompt_cache::size() const {
     size_t res = 0;
 
@@ -1982,27 +2311,403 @@ size_t server_prompt_cache::n_tokens() const {
     return res;
 }
 
-server_prompt * server_prompt_cache::alloc(const server_prompt & prompt, size_t state_size_tgt, size_t state_size_dft) {
+size_t server_prompt_cache::disk_size() const {
+    return disk_size_total;
+}
+
+size_t server_prompt_cache::disk_n_tokens() const {
+    size_t res = 0;
+    for (const auto & state : disk_states) {
+        res += state.n_tokens();
+    }
+    return res;
+}
+
+void server_prompt_cache::disable_disk_saves(const char * reason, const std::string & path) {
+    disk_save_failures++;
+    if (disk_save_disabled) {
+        return;
+    }
+
+    disk_save_disabled = true;
+    SRV_ERR("prompt cache disk writes disabled: reason=%s failures=%" PRIu64 " entries=%zu accounted_bytes=%zu path=%s cache_path=%s\n",
+            reason, disk_save_failures, disk_states.size(), disk_size_total,
+            path.empty() ? "-" : path.c_str(), disk_owned_path.c_str());
+}
+
+bool server_prompt_cache::save(
+        const server_prompt & prompt,
+              llama_context * ctx_main,
+              llama_context * ctx_drft,
+               llama_seq_id   id_slot,
+        const std::vector<uint8_t> & state_spec) {
+    bool saved = false;
+
+    if (!disk_owned_path.empty()) {
+        saved = save_disk(prompt, ctx_main, ctx_drft, id_slot, state_spec) || saved;
+    }
+
+    if (!ram_enabled) {
+        return saved;
+    }
+
+    const size_t state_size_main = llama_state_seq_get_size_ext(ctx_main, id_slot, LLAMA_STATE_SEQ_FLAGS_NONE);
+    const size_t state_size_drft = ctx_drft ? llama_state_seq_get_size_ext(ctx_drft, id_slot, LLAMA_STATE_SEQ_FLAGS_NONE) : 0;
+
+    auto * cur = alloc(prompt, state_size_main, state_size_drft, state_spec);
+    if (cur == nullptr) {
+        return saved;
+    }
+
+    const size_t n_main = llama_state_seq_get_data_ext(
+        ctx_main, cur->data.main.data(), state_size_main, id_slot, LLAMA_STATE_SEQ_FLAGS_NONE);
+    if (n_main != state_size_main) {
+        SRV_ERR("failed to save RAM prompt cache target state: expected=%zu saved=%zu\n", state_size_main, n_main);
+        states.pop_back();
+        return saved;
+    }
+
+    if (ctx_drft) {
+        const size_t n_drft = llama_state_seq_get_data_ext(
+            ctx_drft, cur->data.drft.data(), state_size_drft, id_slot, LLAMA_STATE_SEQ_FLAGS_NONE);
+        if (n_drft != state_size_drft) {
+            SRV_ERR("failed to save RAM prompt cache draft state: expected=%zu saved=%zu\n", state_size_drft, n_drft);
+            states.pop_back();
+            return saved;
+        }
+    }
+
+    return true;
+}
+
+bool server_prompt_cache::save_disk(
+        const server_prompt & prompt,
+              llama_context * ctx_main,
+              llama_context * ctx_drft,
+               llama_seq_id   id_slot,
+        const std::vector<uint8_t> & state_spec) {
+    if (disk_owned_path.empty() || disk_limit_size == 0 || prompt.tokens.empty()) {
+        return false;
+    }
+
+    if (prompt.tokens.has_mtmd) {
+        SRV_WRN("prompt cache disk skip: reason=multimodal tokens=%zu path=%s\n",
+                prompt.tokens.size(), disk_owned_path.c_str());
+        return false;
+    }
+
+    // If a usable cached prompt already contains the current stateless prompt,
+    // retain the more useful state without rewriting the SSD. Stateful MTP
+    // blobs are valid only at their exact token boundary, so they may touch an
+    // equal-token entry but never a longer containing entry.
+    for (auto it = disk_states.begin(); it != disk_states.end();) {
+        if (!it->usable) {
+            ++it;
+            continue;
+        }
+
+        const int lcp = it->tokens.get_common_prefix(prompt.tokens);
+        const bool exact_tokens = lcp == (int) prompt.tokens.size() && it->tokens.size() == prompt.tokens.size();
+        const bool can_touch = state_spec.empty()
+            ? lcp == (int) prompt.tokens.size()
+            : exact_tokens;
+        if (!can_touch) {
+            ++it;
+            continue;
+        }
+
+        const bool pair_shape_ok = !it->path_main.empty() && it->size_main > 0 &&
+            ((ctx_drft != nullptr) == (!it->path_drft.empty() && it->size_drft > 0));
+        const bool spec_shape_ok = state_spec.empty() || !it->spec.empty();
+        size_t actual_main = 0;
+        size_t actual_drft = 0;
+        const bool files_ok = pair_shape_ok && spec_shape_ok &&
+            server_prompt_cache_disk_size_exact(it->path_main, it->size_main, &actual_main) &&
+            server_prompt_cache_disk_size_exact(it->path_drft, it->size_drft, &actual_drft);
+        if (!files_ok) {
+            SRV_WRN("prompt cache disk touch rejected: entry=%" PRIu64 " reason=unusable-pair target_bytes=%zu target_actual=%zu draft_bytes=%zu draft_actual=%zu spec_bytes=%zu path=%s\n",
+                    it->id, it->size_main, actual_main, it->size_drft, actual_drft, it->spec.size(), disk_owned_path.c_str());
+            auto bad = it++;
+            bad->usable = false;
+            if (!erase_disk_state(bad, false, "touch-unusable")) {
+                disable_disk_saves("touch-unusable-removal", disk_owned_path);
+            }
+            continue;
+        }
+
+        {
+            const auto id = it->id;
+            disk_states.splice(disk_states.end(), disk_states, it);
+            SRV_INF("prompt cache disk touch: entry=%" PRIu64 " lcp=%d tokens=%zu exact=%s stateful=%s safe_to_clear=true path=%s\n",
+                    id, lcp, prompt.tokens.size(), exact_tokens ? "true" : "false",
+                    state_spec.empty() ? "false" : "true", disk_owned_path.c_str());
+            return true;
+        }
+    }
+
+    if (disk_save_disabled) {
+        SRV_DBG("prompt cache disk save skip: reason=circuit-open tokens=%zu path=%s\n",
+                prompt.tokens.size(), disk_owned_path.c_str());
+        return false;
+    }
+
+    const auto & tokens = prompt.tokens.get_tokens();
+    const size_t token_bytes = tokens.size()*sizeof(llama_token);
+    const size_t file_overhead = 3*sizeof(uint32_t) + token_bytes;
+    const size_t state_size_main = llama_state_seq_get_size_ext(ctx_main, id_slot, LLAMA_STATE_SEQ_FLAGS_NONE);
+    const size_t state_size_drft = ctx_drft ? llama_state_seq_get_size_ext(ctx_drft, id_slot, LLAMA_STATE_SEQ_FLAGS_NONE) : 0;
+    const size_t predicted_main = state_size_main + file_overhead;
+    const size_t predicted_drft = ctx_drft ? state_size_drft + file_overhead : 0;
+    const size_t predicted_total = predicted_main + predicted_drft;
+
+    if (predicted_total > disk_limit_size) {
+        SRV_WRN("prompt cache disk skip: reason=oversize target_bytes=%zu draft_bytes=%zu total_bytes=%zu limit_bytes=%zu tokens=%zu path=%s\n",
+                predicted_main, predicted_drft, predicted_total, disk_limit_size, tokens.size(), disk_owned_path.c_str());
+        return false;
+    }
+
+    const uint64_t entry_id = disk_next_id++;
+    const fs::path owned = disk_owned_path;
+    const std::string stem = "state-" + std::to_string(entry_id);
+    const fs::path path_main_tmp = owned / (stem + "-target.bin.tmp");
+    const fs::path path_main     = owned / (stem + "-target.bin");
+    const fs::path path_drft_tmp = owned / (stem + "-draft.bin.tmp");
+    const fs::path path_drft     = owned / (stem + "-draft.bin");
+
+    const auto cleanup_temps = [&]() -> bool {
+        const bool main_ok = server_prompt_cache_disk_remove_file(path_main_tmp.string());
+        const bool drft_ok = server_prompt_cache_disk_remove_file(path_drft_tmp.string());
+        return main_ok && drft_ok;
+    };
+    const auto fail_io = [&](const char * reason, const std::string & path) -> bool {
+        const bool cleanup_ok = cleanup_temps();
+        disable_disk_saves(reason, path);
+        if (!cleanup_ok) {
+            disable_disk_saves("temporary-cleanup", disk_owned_path);
+        }
+        return false;
+    };
+
+    const int64_t t_start = ggml_time_us();
+
+    const size_t n_main = llama_state_seq_save_file(
+        ctx_main, path_main_tmp.c_str(), id_slot, tokens.data(), tokens.size());
+    size_t actual_main = 0;
+    if (n_main == 0 ||
+        !server_prompt_cache_disk_size_exact(path_main_tmp.string(), n_main, &actual_main) ||
+        !server_prompt_cache_disk_flush_and_drop(path_main_tmp.string(), true)) {
+        SRV_ERR("prompt cache disk save failed: entry=%" PRIu64 " component=target path=%s\n",
+                entry_id, path_main_tmp.c_str());
+        return fail_io("target-save", path_main_tmp.string());
+    }
+
+    size_t n_drft = 0;
+    if (ctx_drft) {
+        n_drft = llama_state_seq_save_file(
+            ctx_drft, path_drft_tmp.c_str(), id_slot, tokens.data(), tokens.size());
+        size_t actual_drft = 0;
+        if (n_drft == 0 ||
+            !server_prompt_cache_disk_size_exact(path_drft_tmp.string(), n_drft, &actual_drft) ||
+            !server_prompt_cache_disk_flush_and_drop(path_drft_tmp.string(), true)) {
+            SRV_ERR("prompt cache disk save failed: entry=%" PRIu64 " component=draft path=%s\n",
+                    entry_id, path_drft_tmp.c_str());
+            return fail_io("draft-save", path_drft_tmp.string());
+        }
+    }
+
+    const size_t actual_total = n_main + n_drft;
+    if (actual_total > disk_limit_size) {
+        const bool cleanup_ok = cleanup_temps();
+        SRV_WRN("prompt cache disk skip: reason=actual-oversize entry=%" PRIu64 " target_bytes=%zu draft_bytes=%zu total_bytes=%zu limit_bytes=%zu path=%s\n",
+                entry_id, n_main, n_drft, actual_total, disk_limit_size, disk_owned_path.c_str());
+        if (!cleanup_ok) {
+            disable_disk_saves("actual-oversize-cleanup", disk_owned_path);
+        }
+        return false;
+    }
+
+    std::error_code ec;
+    fs::permissions(path_main_tmp, fs::perms::owner_read | fs::perms::owner_write, fs::perm_options::replace, ec);
+    if (ec) {
+        SRV_ERR("prompt cache disk permissions failed: entry=%" PRIu64 " component=target path=%s error=%s\n",
+                entry_id, path_main_tmp.string().c_str(), ec.message().c_str());
+        return fail_io("target-permissions", path_main_tmp.string());
+    }
+    if (ctx_drft) {
+        fs::permissions(path_drft_tmp, fs::perms::owner_read | fs::perms::owner_write, fs::perm_options::replace, ec);
+        if (ec) {
+            SRV_ERR("prompt cache disk permissions failed: entry=%" PRIu64 " component=draft path=%s error=%s\n",
+                    entry_id, path_drft_tmp.string().c_str(), ec.message().c_str());
+            return fail_io("draft-permissions", path_drft_tmp.string());
+        }
+    }
+
+    // The complete target/draft temporary pair is durable. Commit it before
+    // touching older entries so a rename or directory-sync failure cannot
+    // destroy a previously usable cache. This permits one incoming entry of
+    // transient staging headroom above the configured payload limit.
+    ec.clear();
+    fs::rename(path_main_tmp, path_main, ec);
+    if (ec) {
+        SRV_ERR("prompt cache disk atomic rename failed: entry=%" PRIu64 " component=target path=%s error=%s\n",
+                entry_id, path_main.string().c_str(), ec.message().c_str());
+        return fail_io("target-rename", path_main.string());
+    }
+
+    if (ctx_drft) {
+        ec.clear();
+        fs::rename(path_drft_tmp, path_drft, ec);
+        if (ec) {
+            const bool main_cleanup_ok = server_prompt_cache_disk_remove_file(path_main.string());
+            const bool temp_cleanup_ok = cleanup_temps();
+            SRV_ERR("prompt cache disk atomic rename failed: entry=%" PRIu64 " component=draft path=%s error=%s\n",
+                    entry_id, path_drft.string().c_str(), ec.message().c_str());
+            disable_disk_saves("draft-rename", path_drft.string());
+            if (!main_cleanup_ok || !temp_cleanup_ok) {
+                disable_disk_saves("draft-rename-cleanup", disk_owned_path);
+            }
+            return false;
+        }
+    }
+
+    if (!server_prompt_cache_disk_sync_dir(disk_owned_path) ||
+        !server_prompt_cache_disk_flush_and_drop(path_main.string(), false) ||
+        (ctx_drft && !server_prompt_cache_disk_flush_and_drop(path_drft.string(), false))) {
+        const bool main_cleanup_ok = server_prompt_cache_disk_remove_file(path_main.string());
+        const bool drft_cleanup_ok = server_prompt_cache_disk_remove_file(path_drft.string());
+        disable_disk_saves("commit-sync", disk_owned_path);
+        if (!main_cleanup_ok || !drft_cleanup_ok) {
+            disable_disk_saves("commit-sync-cleanup", disk_owned_path);
+        }
+        return false;
+    }
+
+    server_prompt_disk_state state;
+    state.tokens    = prompt.tokens.clone();
+    state.path_main = path_main.string();
+    state.path_drft = ctx_drft ? path_drft.string() : std::string();
+    state.size_main = n_main;
+    state.size_drft = n_drft;
+    state.spec      = state_spec;
+    state.id        = entry_id;
+    state.usable    = true;
+    state.checkpoints.reserve(prompt.checkpoints.size());
+    for (const auto & ckpt : prompt.checkpoints) {
+        state.checkpoints.push_back({ckpt.n_tokens, ckpt.pos_min, ckpt.pos_max});
+    }
+
+    disk_states.push_back(std::move(state));
+    disk_size_total    += actual_total;
+    disk_saves++;
+    disk_bytes_written += actual_total;
+
+    auto new_entry = std::prev(disk_states.end());
+    bool reclaim_ok = true;
+
+    // Stateless entries can supersede shorter prefixes. Stateful MTP blobs
+    // remain independently useful exact-boundary states.
+    if (state_spec.empty()) {
+        for (auto it = disk_states.begin(); it != new_entry;) {
+            const int lcp = it->tokens.get_common_prefix(prompt.tokens);
+            if (lcp == (int) it->tokens.size()) {
+                auto obsolete = it++;
+                if (!erase_disk_state(obsolete, false, "obsolete-prefix")) {
+                    disable_disk_saves("obsolete-reclaim", disk_owned_path);
+                    reclaim_ok = false;
+                    break;
+                }
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    while (reclaim_ok && disk_size_total > disk_limit_size) {
+        if (disk_states.begin() == new_entry) {
+            SRV_ERR("prompt cache disk reclaim failed: entry=%" PRIu64 " reason=no-old-victim accounted_bytes=%zu limit_bytes=%zu path=%s\n",
+                    entry_id, disk_size_total, disk_limit_size, disk_owned_path.c_str());
+            disable_disk_saves("room-not-reclaimed", disk_owned_path);
+            reclaim_ok = false;
+            break;
+        }
+        if (!erase_disk_state(disk_states.begin(), true, "lru-limit")) {
+            disable_disk_saves("lru-reclaim", disk_owned_path);
+            reclaim_ok = false;
+            break;
+        }
+    }
+
+    if (!reclaim_ok) {
+        SRV_WRN("prompt cache disk committed over limit: entry=%" PRIu64 " accounted_bytes=%zu limit_bytes=%zu save_disabled=true path=%s\n",
+                entry_id, disk_size_total, disk_limit_size, disk_owned_path.c_str());
+    }
+
+    const double t_ms = (ggml_time_us() - t_start)/1000.0;
+    SRV_INF("prompt cache disk save: entry=%" PRIu64 " tokens=%zu checkpoints=%zu target_bytes=%zu draft_bytes=%zu spec_bytes=%zu total_bytes=%zu save_ms=%.2f path=%s\n",
+            entry_id, tokens.size(), prompt.checkpoints.size(), n_main, n_drft, state_spec.size(), actual_total, t_ms, disk_owned_path.c_str());
+    log_disk_state();
+
+    return true;
+}
+
+server_prompt * server_prompt_cache::alloc(
+        const server_prompt & prompt,
+                    size_t state_size_tgt,
+                    size_t state_size_dft,
+        const std::vector<uint8_t> & state_spec) {
     // first check if the current state is contained fully in the cache
     for (auto it = states.begin(); it != states.end(); ++it) {
         const int cur_lcp_len = it->tokens.get_common_prefix(prompt.tokens);
+        const bool exact_tokens = cur_lcp_len == (int) prompt.tokens.size() &&
+            it->tokens.size() == prompt.tokens.size();
+        const bool cached_boundary = state_spec.empty()
+            ? cur_lcp_len == (int) prompt.tokens.size()
+            : exact_tokens && !it->data.spec.empty();
 
-        if (cur_lcp_len == (int) prompt.tokens.size()) {
+        if (cached_boundary) {
             SRV_INF("%s", " - prompt is already in the cache, skipping\n");
             return nullptr;
         }
     }
 
-    // next, remove any cached prompts that are fully contained in the current prompt
-    for (auto it = states.begin(); it != states.end();) {
-        const int len = it->tokens.get_common_prefix(prompt.tokens);
+    // calculate checkpoints size to see if it will fit with the prompt
+    size_t checkpoints_size = 0;
+    for (const auto & ckpt : prompt.checkpoints) {
+        checkpoints_size += ckpt.size();
+    }
 
-        if (len == (int) it->tokens.size()) {
-            SRV_WRN(" - removing obsolete cached prompt with length %d\n", len);
+    const size_t state_size_new = state_size_tgt + state_size_dft + state_spec.size() + checkpoints_size;
 
-            it = states.erase(it);
-        } else {
-            ++it;
+    // skip over-limit entries to avoid disturbing the cache
+    if (limit_size > 0 && state_size_new > limit_size) {
+        SRV_WRN(" - prompt state size %.3f MiB exceeds cache size limit %.3f MiB, skipping\n",
+                state_size_new / (1024.0 * 1024.0), limit_size / (1024.0 * 1024.0));
+        return nullptr;
+    }
+
+    // Stateful speculative blobs are exact-boundary states. Keep shorter
+    // boundaries instead of treating them as obsolete prefixes.
+    if (state_spec.empty()) {
+        for (auto it = states.begin(); it != states.end();) {
+            const int len = it->tokens.get_common_prefix(prompt.tokens);
+
+            if (len == (int) it->tokens.size()) {
+                SRV_WRN(" - removing obsolete cached prompt with length %d\n", len);
+
+                it = states.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    if (limit_size > 0) {
+        // make room before allocating the new vectors to avoid breaching the limit
+        while (!states.empty() && size() + state_size_new > limit_size) {
+            SRV_WRN(" - making room for prompt cache entry, removing oldest entry (size = %.3f MiB)\n",
+                    states.front().size() / (1024.0 * 1024.0));
+
+            states.pop_front();
         }
     }
 
@@ -2030,6 +2735,7 @@ server_prompt * server_prompt_cache::alloc(const server_prompt & prompt, size_t 
         /*.data        =*/ {
             /*.main =*/ std::move(state_data_tgt),
             /*.drft =*/ std::move(state_data_dft),
+            /*.spec =*/ state_spec,
         },
         /*.checkpoints =*/ prompt.checkpoints,
     });
@@ -2037,41 +2743,357 @@ server_prompt * server_prompt_cache::alloc(const server_prompt & prompt, size_t 
     return &states.back();
 }
 
-bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tokens_new, llama_context * ctx_tgt, llama_context * ctx_dft, int32_t id_slot) {
+bool server_prompt_cache::load_disk(
+        std::list<server_prompt_disk_state>::iterator it,
+        server_prompt & prompt,
+        llama_context * ctx_tgt,
+        llama_context * ctx_dft,
+         llama_seq_id   id_slot,
+              size_t   lcp,
+            uint64_t * entry_id_out) {
+    if (entry_id_out != nullptr) {
+        *entry_id_out = 0;
+    }
+
+    const uint64_t entry_id = it->id;
+    const size_t target_bytes = it->size_main;
+    const size_t draft_bytes  = it->size_drft;
+    const size_t spec_bytes   = it->spec.size();
+    const size_t total_bytes  = it->size();
+    const size_t n_tokens_expected = it->tokens.size();
+    const size_t n_checkpoints = it->checkpoints.size();
+    const std::string path_main = it->path_main;
+    const std::string path_drft = it->path_drft;
+
+    const auto reject_entry = [&](const char * reason) -> bool {
+        it->usable = false;
+        if (!erase_disk_state(it, false, reason)) {
+            disable_disk_saves("invalid-entry-removal", disk_owned_path);
+        }
+        log_disk_state();
+        return false;
+    };
+
+    // Validate the entire pair before mutating either context.
+    size_t actual_main = 0;
+    size_t actual_drft = 0;
+    if (path_main.empty() || target_bytes == 0 ||
+        !server_prompt_cache_disk_size_exact(path_main, target_bytes, &actual_main)) {
+        SRV_ERR("prompt cache disk load failed: entry=%" PRIu64 " component=target reason=size-mismatch expected_bytes=%zu actual_bytes=%zu path=%s\n",
+                entry_id, target_bytes, actual_main, path_main.c_str());
+        return reject_entry("target-size-mismatch");
+    }
+    if (!path_drft.empty()) {
+        if (ctx_dft == nullptr || draft_bytes == 0 ||
+            !server_prompt_cache_disk_size_exact(path_drft, draft_bytes, &actual_drft)) {
+            SRV_ERR("prompt cache disk load failed: entry=%" PRIu64 " component=draft reason=size-mismatch expected_bytes=%zu actual_bytes=%zu path=%s\n",
+                    entry_id, draft_bytes, actual_drft, path_drft.c_str());
+            return reject_entry("draft-size-mismatch");
+        }
+    } else if (ctx_dft != nullptr || draft_bytes != 0) {
+        SRV_ERR("prompt cache disk load failed: entry=%" PRIu64 " component=draft reason=missing-draft-file expected_bytes=%zu path=%s\n",
+                entry_id, draft_bytes, disk_owned_path.c_str());
+        return reject_entry("missing-draft-file");
+    }
+
+    const int64_t t_start = ggml_time_us();
+
+    llama_tokens tokens_main(n_tokens_expected);
+    size_t n_tokens_main = 0;
+    const size_t nread_main = llama_state_seq_load_file(
+        ctx_tgt, path_main.c_str(), id_slot,
+        tokens_main.data(), tokens_main.size(), &n_tokens_main);
+    tokens_main.resize(n_tokens_main);
+    server_prompt_cache_disk_flush_and_drop(path_main, false);
+
+    if (nread_main != target_bytes || !server_prompt_cache_tokens_equal(it->tokens, tokens_main)) {
+        SRV_ERR("prompt cache disk load failed: entry=%" PRIu64 " component=target expected_bytes=%zu read_bytes=%zu expected_tokens=%zu restored_tokens=%zu path=%s\n",
+                entry_id, target_bytes, nread_main, n_tokens_expected, n_tokens_main, path_main.c_str());
+        return reject_entry("corrupt-target");
+    }
+
+    size_t nread_drft = 0;
+    if (!path_drft.empty()) {
+        llama_tokens tokens_drft(n_tokens_expected);
+        size_t n_tokens_drft = 0;
+        nread_drft = llama_state_seq_load_file(
+            ctx_dft, path_drft.c_str(), id_slot,
+            tokens_drft.data(), tokens_drft.size(), &n_tokens_drft);
+        tokens_drft.resize(n_tokens_drft);
+        server_prompt_cache_disk_flush_and_drop(path_drft, false);
+
+        if (nread_drft != draft_bytes ||
+            !server_prompt_cache_tokens_equal(it->tokens, tokens_drft) ||
+            tokens_drft != tokens_main) {
+            SRV_ERR("prompt cache disk load failed: entry=%" PRIu64 " component=draft expected_bytes=%zu read_bytes=%zu expected_tokens=%zu restored_tokens=%zu path=%s\n",
+                    entry_id, draft_bytes, nread_drft, n_tokens_expected, n_tokens_drft, path_drft.c_str());
+            return reject_entry("corrupt-draft");
+        }
+    }
+
+    server_prompt restored;
+    restored.tokens = it->tokens.clone();
+    restored.data.spec = it->spec;
+    // Intentionally do not recreate common_prompt_checkpoint payloads. The
+    // disk entry retained only their small positions, not cloned host/device
+    // state. Fresh checkpoints are created as processing continues.
+    prompt = std::move(restored);
+
+    disk_bytes_read += nread_main + nread_drft;
+
+    const double t_ms = (ggml_time_us() - t_start)/1000.0;
+    SRV_INF("prompt cache disk load: entry=%" PRIu64 " lcp=%zu tokens=%zu checkpoints=%zu target_bytes=%zu draft_bytes=%zu spec_bytes=%zu total_bytes=%zu read_bytes=%zu load_ms=%.2f path=%s\n",
+            entry_id, lcp, n_tokens_expected, n_checkpoints, target_bytes, draft_bytes, spec_bytes, total_bytes,
+            nread_main + nread_drft, t_ms, disk_owned_path.c_str());
+
+    if (entry_id_out != nullptr) {
+        *entry_id_out = entry_id;
+    }
+    return true;
+}
+
+bool server_prompt_cache::erase_disk_state(
+        std::list<server_prompt_disk_state>::iterator it,
+        bool eviction,
+        const char * reason) {
+    const uint64_t entry_id    = it->id;
+    const size_t target_bytes  = it->size_main;
+    const size_t draft_bytes   = it->size_drft;
+    const size_t spec_bytes    = it->spec.size();
+    const size_t total_bytes   = it->size();
+    const size_t tokens        = it->tokens.size();
+    const std::string path_main = it->path_main;
+    const std::string path_drft = it->path_drft;
+
+    // Quarantine before touching either component. If only one unlink works,
+    // retain the full conservative accounting and metadata for a later retry.
+    it->usable = false;
+    const bool main_ok = server_prompt_cache_disk_remove_file(path_main);
+    const bool drft_ok = server_prompt_cache_disk_remove_file(path_drft);
+    if (!main_ok || !drft_ok) {
+        SRV_ERR("prompt cache disk removal failed: entry=%" PRIu64 " reason=%s target_removed=%s draft_removed=%s accounted_bytes=%zu path=%s\n",
+                entry_id, reason, main_ok ? "true" : "false", drft_ok ? "true" : "false",
+                disk_size_total, disk_owned_path.c_str());
+        return false;
+    }
+
+    if (total_bytes > disk_size_total) {
+        SRV_ERR("prompt cache disk accounting invariant failed: entry=%" PRIu64 " entry_bytes=%zu accounted_bytes=%zu path=%s\n",
+                entry_id, total_bytes, disk_size_total, disk_owned_path.c_str());
+        return false;
+    }
+    disk_size_total -= total_bytes;
+
+    if (eviction) {
+        disk_evictions++;
+        disk_bytes_evicted += total_bytes;
+        SRV_INF("prompt cache disk eviction: entry=%" PRIu64 " reason=%s tokens=%zu target_bytes=%zu draft_bytes=%zu spec_bytes=%zu total_bytes=%zu remaining_bytes=%zu path=%s\n",
+                entry_id, reason, tokens, target_bytes, draft_bytes, spec_bytes, total_bytes, disk_size_total, disk_owned_path.c_str());
+    } else {
+        SRV_INF("prompt cache disk remove: entry=%" PRIu64 " reason=%s tokens=%zu target_bytes=%zu draft_bytes=%zu spec_bytes=%zu total_bytes=%zu remaining_bytes=%zu path=%s\n",
+                entry_id, reason, tokens, target_bytes, draft_bytes, spec_bytes, total_bytes, disk_size_total, disk_owned_path.c_str());
+    }
+
+    disk_states.erase(it);
+    return true;
+}
+
+void server_prompt_cache::accept_disk_load(uint64_t entry_id) {
+    if (entry_id == 0) {
+        return;
+    }
+
+    for (auto it = disk_states.begin(); it != disk_states.end(); ++it) {
+        if (it->id != entry_id || !it->usable) {
+            continue;
+        }
+
+        disk_loads++;
+        disk_states.splice(disk_states.end(), disk_states, it);
+        SRV_INF("prompt cache disk load accepted: entry=%" PRIu64 " reusable=true path=%s\n",
+                entry_id, disk_owned_path.c_str());
+        log_disk_state();
+        return;
+    }
+}
+
+void server_prompt_cache::reject_disk_load(uint64_t entry_id, const char * reason) {
+    if (entry_id == 0) {
+        return;
+    }
+
+    for (auto it = disk_states.begin(); it != disk_states.end(); ++it) {
+        if (it->id != entry_id) {
+            continue;
+        }
+
+        it->usable = false;
+        SRV_WRN("prompt cache disk load rejected: entry=%" PRIu64 " reason=%s reusable=false path=%s\n",
+                entry_id, reason, disk_owned_path.c_str());
+        if (!erase_disk_state(it, false, reason)) {
+            disable_disk_saves("rejected-load-removal", disk_owned_path);
+        }
+        log_disk_state();
+        return;
+    }
+}
+
+void server_prompt_cache::update_disk() {
+    while (!disk_states.empty() && disk_size_total > disk_limit_size) {
+        if (!erase_disk_state(disk_states.begin(), true, "lru-update-limit")) {
+            disable_disk_saves("update-limit-removal", disk_owned_path);
+            break;
+        }
+    }
+
+    log_disk_state();
+}
+
+void server_prompt_cache::log_disk_state() const {
+    if (disk_owned_path.empty()) {
+        return;
+    }
+
+    const size_t unusable = std::count_if(disk_states.begin(), disk_states.end(),
+        [](const server_prompt_disk_state & state) { return !state.usable; });
+    SRV_INF("prompt cache disk state: entries=%zu unusable=%zu bytes=%zu limit_bytes=%zu over_limit=%s tokens=%zu saves=%" PRIu64 " loads=%" PRIu64 " evictions=%" PRIu64 " save_disabled=%s save_failures=%" PRIu64 " bytes_written=%" PRIu64 " bytes_read=%" PRIu64 " bytes_evicted=%" PRIu64 " path=%s\n",
+            disk_states.size(), unusable, disk_size_total, disk_limit_size,
+            disk_size_total > disk_limit_size ? "true" : "false", disk_n_tokens(),
+            disk_saves, disk_loads, disk_evictions, disk_save_disabled ? "true" : "false", disk_save_failures,
+            disk_bytes_written, disk_bytes_read, disk_bytes_evicted,
+            disk_owned_path.c_str());
+}
+
+bool server_prompt_cache::load(
+              server_prompt & prompt,
+        const server_tokens & tokens_new,
+              llama_context * ctx_tgt,
+              llama_context * ctx_dft,
+                    int32_t   id_slot,
+                       bool   spec_state_required,
+                       bool * cache_hit,
+                   uint64_t * disk_entry_id) {
+    if (cache_hit != nullptr) {
+        *cache_hit = false;
+    }
+    if (disk_entry_id != nullptr) {
+        *disk_entry_id = 0;
+    }
+
     const int lcp_best = prompt.tokens.get_common_prefix(tokens_new);
 
-    float f_keep_best = prompt.tokens.size() > 0 ? float(lcp_best) / prompt.tokens.size() : -1.0f; // empty slot: any cache entry wins
-    float sim_best    = float(lcp_best) / tokens_new.size();
+    const bool base_boundary_valid = !spec_state_required ||
+        lcp_best == (int) prompt.tokens.size();
+    float f_keep_best = base_boundary_valid && prompt.tokens.size() > 0 ? float(lcp_best) / prompt.tokens.size() : -1.0f; // empty slot: any cache entry wins
+    float sim_best    = base_boundary_valid ? float(lcp_best) / std::max<size_t>(1, tokens_new.size()) : -1.0f;
+
+    if (spec_state_required && !prompt.tokens.empty() && !base_boundary_valid) {
+        SRV_INF("prompt cache skip: reason=spec-boundary-mismatch source=slot lcp=%d cached_tokens=%zu request_tokens=%zu\n",
+                lcp_best, prompt.tokens.size(), tokens_new.size());
+    }
 
     SRV_INF(" - looking for better prompt, base f_keep = %.3f, sim = %.3f\n", f_keep_best, sim_best);
 
-    auto it_best = states.end();
+    auto it_best_ram  = states.end();
+    auto it_best_disk = disk_states.end();
+    size_t lcp_selected = 0;
+    size_t spec_boundary_best = base_boundary_valid ? prompt.tokens.size() : 0;
+    bool ram_loaded = false;
 
-    // find the most similar cached prompt, that would also preserve the most context
+    // Find the most similar RAM prompt first. On an equal match, the hot RAM
+    // copy wins and avoids SSD I/O.
     for (auto it = states.begin(); it != states.end(); ++it) {
         const int lcp_cur = it->tokens.get_common_prefix(tokens_new);
 
-        const float f_keep_cur = float(lcp_cur) / it->tokens.size();
-        const float sim_cur    = float(lcp_cur) / tokens_new.size();
+        if (spec_state_required &&
+            lcp_cur != (int) it->tokens.size()) {
+            SRV_INF("prompt cache skip: reason=spec-boundary-mismatch source=ram lcp=%d cached_tokens=%zu request_tokens=%zu spec_bytes=%zu\n",
+                    lcp_cur, it->tokens.size(), tokens_new.size(), it->data.spec.size());
+            continue;
+        }
+        if (spec_state_required && it->data.spec.empty()) {
+            SRV_INF("prompt cache skip: reason=spec-state-missing source=ram cached_tokens=%zu request_tokens=%zu\n",
+                    it->tokens.size(), tokens_new.size());
+            continue;
+        }
+
+        const float f_keep_cur = float(lcp_cur) / std::max<size_t>(1, it->tokens.size());
+        const float sim_cur    = float(lcp_cur) / std::max<size_t>(1, tokens_new.size());
 
         // don't trash large prompts
         if (f_keep_cur < 0.25f) {
             continue;
         }
 
-        if (f_keep_best < f_keep_cur && sim_best < sim_cur) {
+        const bool is_better = spec_state_required
+            ? it->tokens.size() > spec_boundary_best
+            : f_keep_best < f_keep_cur && sim_best < sim_cur;
+        if (is_better) {
             f_keep_best = f_keep_cur;
             sim_best    = sim_cur;
+            spec_boundary_best = it->tokens.size();
 
-            it_best = it;
+            it_best_ram  = it;
+            it_best_disk = disk_states.end();
+            lcp_selected = lcp_cur;
         }
     }
 
-    if (it_best != states.end()) {
+    for (auto it = disk_states.begin(); it != disk_states.end(); ++it) {
+        if (!it->usable) {
+            continue;
+        }
+
+        const int lcp_cur = it->tokens.get_common_prefix(tokens_new);
+
+        if (spec_state_required &&
+            lcp_cur != (int) it->tokens.size()) {
+            SRV_INF("prompt cache skip: reason=spec-boundary-mismatch source=disk entry=%" PRIu64 " lcp=%d cached_tokens=%zu request_tokens=%zu spec_bytes=%zu\n",
+                    it->id, lcp_cur, it->tokens.size(), tokens_new.size(), it->spec.size());
+            continue;
+        }
+        if (spec_state_required && it->spec.empty()) {
+            SRV_INF("prompt cache skip: reason=spec-state-missing source=disk entry=%" PRIu64 " cached_tokens=%zu request_tokens=%zu\n",
+                    it->id, it->tokens.size(), tokens_new.size());
+            continue;
+        }
+
+        const float f_keep_cur = float(lcp_cur) / std::max<size_t>(1, it->tokens.size());
+        const float sim_cur    = float(lcp_cur) / std::max<size_t>(1, tokens_new.size());
+
+        if (f_keep_cur < 0.25f) {
+            continue;
+        }
+
+        const bool is_better = spec_state_required
+            ? it->tokens.size() > spec_boundary_best
+            : f_keep_best < f_keep_cur && sim_best < sim_cur;
+        if (is_better) {
+            f_keep_best = f_keep_cur;
+            sim_best    = sim_cur;
+            spec_boundary_best = it->tokens.size();
+
+            it_best_ram  = states.end();
+            it_best_disk = it;
+            lcp_selected = lcp_cur;
+        }
+    }
+
+    if (it_best_disk != disk_states.end()) {
+        SRV_INF(" - found better disk prompt with f_keep = %.3f, sim = %.3f, lcp = %zu\n",
+                f_keep_best, sim_best, lcp_selected);
+        const bool loaded = load_disk(it_best_disk, prompt, ctx_tgt, ctx_dft, id_slot, lcp_selected, disk_entry_id);
+        if (loaded && cache_hit != nullptr) {
+            *cache_hit = true;
+        }
+        return loaded;
+    }
+
+    if (it_best_ram != states.end()) {
         SRV_INF(" - found better prompt with f_keep = %.3f, sim = %.3f\n", f_keep_best, sim_best);
 
         {
-            auto & data = it_best->data.main;
+            auto & data = it_best_ram->data.main;
 
             const size_t size = data.size();
             const size_t n = llama_state_seq_set_data_ext(ctx_tgt, data.data(), size, id_slot, 0);
@@ -2086,7 +3108,7 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
         }
 
         {
-            auto & data = it_best->data.drft;
+            auto & data = it_best_ram->data.drft;
 
             if (!data.empty()) {
                 GGML_ASSERT(ctx_dft);
@@ -2104,22 +3126,22 @@ bool server_prompt_cache::load(server_prompt & prompt, const server_tokens & tok
             }
         }
 
-        prompt = std::move(*it_best);
+        prompt = std::move(*it_best_ram);
 
-        states.erase(it_best);
+        states.erase(it_best_ram);
+
+        if (cache_hit != nullptr) {
+            *cache_hit = true;
+        }
+        ram_loaded = true;
     }
 
-    return true;
+    return base_boundary_valid || ram_loaded;
 }
 
 void server_prompt_cache::update() {
     if (limit_size > 0) {
-        // always keep at least one state, regardless of the limits
-        while (states.size() > 1 && size() > limit_size) {
-            if (states.empty()) {
-                break;
-            }
-
+        while (!states.empty() && size() > limit_size) {
             SRV_WRN(" - cache size limit reached, removing oldest entry (size = %.3f MiB)\n", states.front().size() / (1024.0 * 1024.0));
 
             states.pop_front();
@@ -2133,11 +3155,7 @@ void server_prompt_cache::update() {
     const size_t limit_tokens_cur = limit_size > 0 ? std::max<size_t>(limit_tokens, limit_size/size_per_token) : limit_tokens;
 
     if (limit_tokens > 0) {
-        while (states.size() > 1 && n_tokens() > limit_tokens_cur) {
-            if (states.empty()) {
-                break;
-            }
-
+        while (!states.empty() && n_tokens() > limit_tokens_cur) {
             SRV_WRN(" - cache token limit (%zu, est: %zu) reached, removing oldest entry (size = %.3f MiB)\n",
                     limit_tokens, limit_tokens_cur, states.front().size() / (1024.0 * 1024.0));
 
@@ -2152,4 +3170,6 @@ void server_prompt_cache::update() {
         SRV_INF("   - prompt %p: %7d tokens, checkpoints: %2zu, %9.3f MiB\n",
                 (const void *)&state, state.n_tokens(), state.checkpoints.size(), state.size() / (1024.0 * 1024.0));
     }
+
+    update_disk();
 }

--- a/tools/server/server-task.h
+++ b/tools/server/server-task.h
@@ -568,9 +568,10 @@ struct server_task_result_apply_lora : server_task_result {
 struct server_prompt_data {
     std::vector<uint8_t> main;
     std::vector<uint8_t> drft;
+    std::vector<uint8_t> spec;
 
     size_t size() const {
-        return main.size() + drft.size();
+        return main.size() + drft.size() + spec.size();
     }
 };
 
@@ -606,13 +607,55 @@ struct server_prompt {
     }
 };
 
-struct server_prompt_cache {
-    server_prompt_cache(int32_t limit_size_mib, size_t limit_tokens) {
-        this->limit_size   = 1024ull*1024ull*(limit_size_mib < 0 ? 0 : limit_size_mib);
-        this->limit_tokens = limit_tokens;
+// The context checkpoint payloads may contain large host vectors and cloned
+// backend buffers. Disk-cache entries keep only the small scheduling metadata;
+// a restored disk state starts with an empty live checkpoint list and creates
+// fresh checkpoints as prompt processing continues.
+struct server_prompt_checkpoint_meta {
+    int64_t   n_tokens = 0;
+    llama_pos pos_min  = 0;
+    llama_pos pos_max  = 0;
+};
+
+struct server_prompt_disk_state {
+    server_tokens tokens;
+    std::vector<server_prompt_checkpoint_meta> checkpoints;
+    std::vector<uint8_t> spec;
+
+    std::string path_main;
+    std::string path_drft;
+
+    size_t size_main = 0;
+    size_t size_drft = 0;
+
+    uint64_t id = 0;
+    bool usable = true;
+
+    size_t size() const {
+        return size_main + size_drft;
     }
 
+    int n_tokens() const {
+        return tokens.size();
+    }
+};
+
+struct server_prompt_cache {
+    server_prompt_cache(
+            int32_t limit_size_mib,
+             size_t limit_tokens,
+        const std::string & disk_base_path = {},
+            int32_t disk_limit_size_mib = 0);
+
+    ~server_prompt_cache();
+
     std::list<server_prompt> states;
+
+    // Cold automatic cache. Entries own only token/checkpoint metadata in RAM;
+    // target and draft context payloads live in owner-only files.
+    std::list<server_prompt_disk_state> disk_states;
+
+    bool ram_enabled = false;
 
     // in bytes, 0 = no limit
     size_t limit_size = 0;
@@ -620,13 +663,88 @@ struct server_prompt_cache {
     // in tokens, 0 = no limit
     size_t limit_tokens = 0;
 
+    // Disk fields are disabled when disk_owned_path is empty.
+    std::string disk_base_path;
+    std::string disk_owned_path;
+    size_t disk_limit_size = 0;
+    size_t disk_size_total = 0;
+    int disk_lock_fd = -1;
+
+    uint64_t disk_next_id       = 1;
+    uint64_t disk_saves         = 0;
+    uint64_t disk_loads         = 0;
+    uint64_t disk_evictions     = 0;
+    uint64_t disk_bytes_written = 0;
+    uint64_t disk_bytes_read    = 0;
+    uint64_t disk_bytes_evicted = 0;
+    uint64_t disk_save_failures = 0;
+
+    // A durable write/removal failure opens this run-level circuit breaker.
+    // Existing valid entries remain readable, but no further state files are
+    // created for this server process.
+    bool disk_save_disabled = false;
+
     size_t size() const;
 
     size_t n_tokens() const;
 
-    server_prompt * alloc(const server_prompt & prompt, size_t state_size_main, size_t state_size_drft);
+    size_t disk_size() const;
 
-    bool load(server_prompt & prompt, const server_tokens & tokens_new, llama_context * ctx_main, llama_context * ctx_drft, int32_t id_slot);
+    size_t disk_n_tokens() const;
+
+    bool save(
+        const server_prompt & prompt,
+              llama_context * ctx_main,
+              llama_context * ctx_drft,
+               llama_seq_id   id_slot,
+        const std::vector<uint8_t> & state_spec);
+
+    server_prompt * alloc(
+        const server_prompt & prompt,
+                    size_t state_size_main,
+                    size_t state_size_drft,
+        const std::vector<uint8_t> & state_spec);
+
+    bool load(
+              server_prompt & prompt,
+        const server_tokens & tokens_new,
+              llama_context * ctx_main,
+              llama_context * ctx_drft,
+                    int32_t   id_slot,
+                       bool   spec_state_required,
+                       bool * cache_hit,
+                   uint64_t * disk_entry_id);
+
+    // Called when a stateful speculative implementation rejects a blob after
+    // the target/draft files themselves restored successfully.
+    void accept_disk_load(uint64_t entry_id);
+
+    void reject_disk_load(uint64_t entry_id, const char * reason);
 
     void update();
+
+private:
+    bool save_disk(
+        const server_prompt & prompt,
+              llama_context * ctx_main,
+              llama_context * ctx_drft,
+               llama_seq_id   id_slot,
+        const std::vector<uint8_t> & state_spec);
+
+    bool load_disk(
+        std::list<server_prompt_disk_state>::iterator it,
+        server_prompt & prompt,
+        llama_context * ctx_main,
+        llama_context * ctx_drft,
+         llama_seq_id   id_slot,
+              size_t   lcp,
+            uint64_t * entry_id_out);
+
+    bool erase_disk_state(std::list<server_prompt_disk_state>::iterator it, bool eviction, const char * reason);
+
+    void disable_disk_saves(const char * reason, const std::string & path);
+
+    void update_disk();
+
+    void log_disk_state() const;
 };

--- a/tools/server/tests/unit/test_prompt_cache_disk.py
+++ b/tools/server/tests/unit/test_prompt_cache_disk.py
@@ -1,0 +1,320 @@
+import math
+import os
+import re
+import socket
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from utils import *
+
+
+LONG_PROMPT = (
+    "Once upon a time in a land far away, there lived a brave knight "
+    "who traveled across mountains and rivers to find the legendary "
+    "golden sword hidden deep within the enchanted forest of whispers. "
+    "He met many creatures along the way including dragons and fairies "
+    "and wizards who helped him on his noble quest to save the kingdom."
+)
+
+MODEL_DRAFT_FILE_URL = "https://huggingface.co/ggml-org/tiny-llamas/resolve/main/stories15M-q4_0.gguf"
+MODEL_TARGET_FILE_URL = "https://huggingface.co/ggml-org/test-model-stories260K/resolve/main/stories260K-f32.gguf"
+MODEL_TARGET_DRAFT_PAIR_FILE_URL = "https://huggingface.co/ggml-org/tiny-llamas/resolve/main/stories15M.gguf"
+
+server = ServerPreset.tinyllama2()
+
+
+# This module uses two explicit tiny local files. Do not invoke the parent
+# conftest's all-preset Hugging Face preload, which is unrelated to this test
+# and prevents offline/no-HTTPS server builds from reaching the assertions.
+@pytest.fixture(scope="module", autouse=True)
+def do_something():
+    yield
+
+
+class LogReader:
+    def __init__(self, path):
+        self.path = path
+        self.pos = 0
+
+    def drain(self):
+        with open(self.path) as f:
+            f.seek(self.pos)
+            content = f.read()
+            self.pos = f.tell()
+        return content
+
+
+def configure_disk_server(cache_dir, limit_mib=64, draft=False):
+    global server
+    server = ServerPreset.tinyllama2()
+    server.model_file = download_file(
+        MODEL_TARGET_DRAFT_PAIR_FILE_URL if draft else MODEL_TARGET_FILE_URL
+    )
+    server.model_hf_repo = None
+    server.model_hf_file = None
+    # Keep the test isolated from a developer shell that already exports a
+    # llama-server API key.
+    server.api_key = os.environ.get("LLAMA_API_KEY")
+    with socket.socket() as sock:
+        sock.bind((server.server_host, 0))
+        server.server_port = sock.getsockname()[1]
+    server.n_slots = 2
+    server.n_ctx = 512
+    server.n_gpu_layer = 0
+    server.n_gpu_layer_draft = 0 if draft else None
+    server.n_predict = 1
+    server.temperature = 0.0
+    server.server_slots = True
+    server.cache_ram = 0
+    server.cache_disk = cache_dir
+    server.cache_disk_limit = limit_mib
+    server.kv_unified = True
+    server.debug = True
+    if draft:
+        server.model_draft = download_file(MODEL_DRAFT_FILE_URL)
+        server.spec_draft_n_min = 1
+        server.spec_draft_n_max = 4
+        server.fa = "off"
+    fd, server.log_path = tempfile.mkstemp(suffix=".log")
+    os.close(fd)
+    return server
+
+
+def complete(prompt, id_slot=None):
+    data = {
+        "prompt": prompt,
+        "cache_prompt": True,
+        "n_predict": 1,
+        "temperature": 0.0,
+    }
+    if id_slot is not None:
+        data["id_slot"] = id_slot
+    headers = {"Authorization": f"Bearer {server.api_key}"} if server.api_key else None
+    res = server.make_request("POST", "/completion", data=data, headers=headers)
+    assert res.status_code == 200
+    return res
+
+
+def prime_and_displace(prompt=LONG_PROMPT):
+    original = complete(prompt, 0)
+    complete("The quick brown fox checks a different cache slot.", 1)
+    return original
+
+
+def test_disk_only_parse_restore_and_owned_cleanup(tmp_path):
+    configure_disk_server(str(tmp_path), limit_mib=64)
+    server.start()
+    log = LogReader(server.log_path)
+
+    startup = log.drain()
+    assert "prompt cache RAM disabled: limit_mib=0" in startup
+    assert "prompt cache SSD enabled:" in startup
+    assert "__TEST_TAG_CACHE_IDLE_SLOTS_ENABLED__" in startup
+
+    original = prime_and_displace()
+    saved = log.drain()
+    assert re.search(r"prompt cache disk save: .*target_bytes=[1-9][0-9]* draft_bytes=0", saved)
+    assert re.search(r"cache state: 0 prompts,", saved)
+
+    restored = complete(LONG_PROMPT)
+    loaded = log.drain()
+    assert "prompt cache disk load:" in loaded
+    assert "draft_bytes=0" in loaded
+    assert restored.body["timings"]["cache_n"] > 0
+    assert restored.body["timings"]["prompt_n"] < original.body["timings"]["prompt_n"]
+
+    # A successful load remains a reusable MRU entry. Saving the restored idle
+    # slot should touch it, then a second restore should hit the same entry.
+    first_entry = re.search(r"prompt cache disk load: entry=([0-9]+)", loaded)
+    assert first_entry is not None
+    complete("A third prompt displaces the restored slot safely.", 1)
+    touched = log.drain()
+    assert f"prompt cache disk touch: entry={first_entry.group(1)}" in touched
+    assert "safe_to_clear=true" in touched
+
+    restored_again = complete(LONG_PROMPT)
+    loaded_again = log.drain()
+    assert f"prompt cache disk load: entry={first_entry.group(1)}" in loaded_again
+    assert "prompt cache disk load accepted:" in loaded_again
+    assert restored_again.body["timings"]["cache_n"] > 0
+
+    namespace = tmp_path / ".llama-prompt-cache-v1"
+    owned = list(namespace.glob("run-*"))
+    assert len(owned) == 1
+    assert not list(owned[0].glob("*.tmp"))
+
+    server.stop()
+    assert not list(namespace.glob("run-*"))
+    assert not list(namespace.glob(".deleting-run-*"))
+
+
+def test_disk_lru_enforces_mib_limit(tmp_path):
+    # Measure this fixture's streamed state size first, then restart with a
+    # model-independent limit that fits a few entries and must evict under load.
+    measure_dir = tmp_path / "measure"
+    configure_disk_server(str(measure_dir), limit_mib=64)
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+    prime_and_displace()
+    measured_log = log.drain()
+    match = re.search(r"prompt cache disk save: .*total_bytes=([1-9][0-9]*)", measured_log)
+    assert match is not None
+    entry_bytes = int(match.group(1))
+    server.stop()
+
+    limit_mib = max(1, math.ceil((entry_bytes * 3) / (1024 * 1024)))
+    cache_dir = tmp_path / "bounded"
+    configure_disk_server(str(cache_dir), limit_mib=limit_mib)
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    # Equal-length, non-prefix prompts produce similarly sized independent LRU
+    # entries. Twenty-four turns is deliberately above the measured capacity.
+    for i in range(24):
+        complete((f"Cache lane {i:02d} unique marker. " * 18), i % 2)
+
+    bounded_log = log.drain()
+    assert "prompt cache disk eviction:" in bounded_log
+    state_lines = [line for line in bounded_log.splitlines() if "prompt cache disk state:" in line]
+    assert state_lines
+    final_state = state_lines[-1]
+    bytes_match = re.search(r" bytes=([0-9]+) limit_bytes=([0-9]+) ", final_state)
+    assert bytes_match is not None
+    assert int(bytes_match.group(1)) <= int(bytes_match.group(2)) == limit_mib * 1024 * 1024
+
+    run_dirs = list((cache_dir / ".llama-prompt-cache-v1").glob("run-*"))
+    assert len(run_dirs) == 1
+    payload_bytes = sum(path.stat().st_size for path in run_dirs[0].glob("state-*.bin"))
+    assert payload_bytes <= limit_mib * 1024 * 1024
+
+
+def test_disk_cache_round_trips_target_and_draft(tmp_path):
+    configure_disk_server(str(tmp_path), limit_mib=64, draft=True)
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    original = prime_and_displace()
+    saved = log.drain()
+    save_match = re.search(
+        r"prompt cache disk save: .*target_bytes=([1-9][0-9]*) draft_bytes=([1-9][0-9]*)",
+        saved,
+    )
+    assert save_match is not None
+
+    restored = complete(LONG_PROMPT)
+    loaded = log.drain()
+    load_match = re.search(
+        r"prompt cache disk load: .*target_bytes=([1-9][0-9]*) draft_bytes=([1-9][0-9]*)",
+        loaded,
+    )
+    assert load_match is not None
+    assert "prompt cache cold fallback:" not in loaded
+    assert restored.body["timings"]["cache_n"] > 0
+    assert restored.body["timings"]["prompt_n"] < original.body["timings"]["prompt_n"]
+
+
+def test_disk_cache_rejects_partial_target_draft_pair(tmp_path):
+    configure_disk_server(str(tmp_path), limit_mib=64, draft=True)
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    original = prime_and_displace()
+    saved = log.drain()
+    assert re.search(
+        r"prompt cache disk save: .*target_bytes=[1-9][0-9]* draft_bytes=[1-9][0-9]*",
+        saved,
+    )
+    assert re.search(r"cache state: 0 prompts,", saved)
+
+    run_dirs = list((tmp_path / ".llama-prompt-cache-v1").glob("run-*"))
+    assert len(run_dirs) == 1
+    draft_files = list(run_dirs[0].glob("state-*-draft.bin"))
+    assert draft_files
+    draft_files[0].unlink()
+
+    restored = complete(LONG_PROMPT)
+    rejected = log.drain()
+    assert "prompt cache disk load failed:" in rejected
+    assert "component=draft" in rejected
+    assert "prompt cache cold fallback:" in rejected
+    assert "target_and_draft_cleared=true" in rejected
+    assert restored.body["timings"]["cache_n"] == 0
+    assert restored.body["timings"]["prompt_n"] == original.body["timings"]["prompt_n"]
+
+    # A rejected pair must not poison the slot or the server.
+    healthy = complete("The server remains healthy after a rejected cache pair.")
+    assert healthy.status_code == 200
+
+
+def test_disk_save_failure_opens_breaker_and_preserves_idle_slot(tmp_path):
+    configure_disk_server(str(tmp_path), limit_mib=64)
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    original = complete(LONG_PROMPT, 0)
+    run_dirs = list((tmp_path / ".llama-prompt-cache-v1").glob("run-*"))
+    assert len(run_dirs) == 1
+
+    # Remove directory write permission so the first target temp cannot be
+    # created. The slot must remain live because no durable cache exists.
+    run_dirs[0].chmod(0o500)
+    try:
+        complete("This request forces an idle-slot save failure.", 1)
+    finally:
+        run_dirs[0].chmod(0o700)
+
+    failed = log.drain()
+    assert "prompt cache disk writes disabled:" in failed
+    assert "reason=target-save" in failed
+    assert "preserving idle slot because prompt cache save was not safe" in failed
+    assert "safe_to_clear=true" not in failed
+
+    reused_live_slot = complete(LONG_PROMPT, 0)
+    after_breaker = log.drain()
+    assert "reason=circuit-open" in after_breaker
+    assert reused_live_slot.body["timings"]["cache_n"] > 0
+    assert reused_live_slot.body["timings"]["prompt_n"] < original.body["timings"]["prompt_n"]
+
+
+def test_failed_corrupt_entry_removal_keeps_conservative_accounting(tmp_path):
+    configure_disk_server(str(tmp_path), limit_mib=64)
+    server.start()
+    log = LogReader(server.log_path)
+    log.drain()
+
+    original = prime_and_displace()
+    saved = log.drain()
+    size_match = re.search(r"prompt cache disk save: .*total_bytes=([1-9][0-9]*)", saved)
+    assert size_match is not None
+    accounted = int(size_match.group(1))
+
+    run_dirs = list((tmp_path / ".llama-prompt-cache-v1").glob("run-*"))
+    assert len(run_dirs) == 1
+    target_files = list(run_dirs[0].glob("state-*-target.bin"))
+    assert target_files
+    with target_files[0].open("r+b") as f:
+        f.truncate(max(1, accounted // 2))
+
+    # Prevent quarantine cleanup. The entry must remain fully accounted and
+    # unusable rather than being reported as freed after unlink failure.
+    run_dirs[0].chmod(0o500)
+    try:
+        restored = complete(LONG_PROMPT)
+    finally:
+        run_dirs[0].chmod(0o700)
+
+    rejected = log.drain()
+    assert "reason=size-mismatch" in rejected
+    assert "prompt cache disk removal failed:" in rejected
+    assert f"accounted_bytes={accounted}" in rejected
+    assert re.search(rf"prompt cache disk state: entries=1 unusable=1 bytes={accounted} ", rejected)
+    assert "save_disabled=true" in rejected
+    assert restored.body["timings"]["cache_n"] == 0
+    assert restored.body["timings"]["prompt_n"] == original.body["timings"]["prompt_n"]

--- a/tools/server/tests/utils.py
+++ b/tools/server/tests/utils.py
@@ -64,6 +64,7 @@ class ServerProcess:
     model_draft: str | None = None
     n_threads: int | None = None
     n_gpu_layer: int | None = None
+    n_gpu_layer_draft: int | None = None
     n_batch: int | None = None
     n_ubatch: int | None = None
     n_ctx: int | None = None
@@ -105,6 +106,8 @@ class ServerProcess:
     media_path: str | None = None
     sleep_idle_seconds: int | None = None
     cache_ram: int | None = None
+    cache_disk: str | None = None
+    cache_disk_limit: int | None = None
     no_cache_idle_slots: bool = False
     log_path: str | None = None
     webui_mcp_proxy: bool = False
@@ -172,8 +175,10 @@ class ServerProcess:
             server_args.extend(["--ubatch-size", self.n_ubatch])
         if self.n_threads:
             server_args.extend(["--threads", self.n_threads])
-        if self.n_gpu_layer:
+        if self.n_gpu_layer is not None:
             server_args.extend(["--n-gpu-layers", self.n_gpu_layer])
+        if self.n_gpu_layer_draft is not None:
+            server_args.extend(["--n-gpu-layers-draft", self.n_gpu_layer_draft])
         if self.server_continuous_batching:
             server_args.append("--cont-batching")
         if self.server_embeddings:
@@ -249,6 +254,10 @@ class ServerProcess:
             server_args.extend(["--sleep-idle-seconds", self.sleep_idle_seconds])
         if self.cache_ram is not None:
             server_args.extend(["--cache-ram", self.cache_ram])
+        if self.cache_disk is not None:
+            server_args.extend(["--cache-disk", self.cache_disk])
+        if self.cache_disk_limit is not None:
+            server_args.extend(["--cache-disk-limit", self.cache_disk_limit])
         if self.no_cache_idle_slots:
             server_args.append("--no-cache-idle-slots")
         if self.webui_mcp_proxy:


### PR DESCRIPTION
## What changed

- add `--cache-disk PATH` and `--cache-disk-limit N` for an automatic SSD-backed prompt cache, including disk-only operation with `--cache-ram 0`
- stream target and draft sequence state separately into an owner-only, process-scoped cache directory
- commit cache pairs atomically, enforce a bounded LRU, validate exact sizes on read, and fail closed on partial write/read/unlink failures
- serialize the stateful MTP boundary alongside the sequence state and restore it through a two-phase accept/reject path
- rebase MTP and Eagle3 deferred-boundary positions when context shift moves the KV window
- add six focused server tests for disk-only restore, target+draft pairing, bounded eviction, reusable loads, save failure, and conservative corruption accounting

## Why

The existing automatic prompt cache keeps complete target and draft sequence-state vectors in host RAM. On large stateful-MTP models, that turns prompt reuse into multi-gigabyte resident-memory growth; an 8 GiB RAM-cache run was OOM-killed while attempting its next cache save. Moving the large sequence payloads to SSD keeps only small token/checkpoint/speculative metadata resident.

Stateful MTP also needs more than the target KV state. A restored sequence must carry the exact current and immediately previous hidden boundary, and context shift must rebase the saved positions. Without that, a cache hit can restore target/draft KV successfully but leave speculative decoding at the wrong boundary.

## User impact

Users can enable the cold tier with:

```text
--cache-ram 0 \
--cache-disk /path/on/fast/ssd \
--cache-disk-limit 16384
```

This is particularly useful for the HY3 FPX-IFP2 lane, whose ROCmFPX codebook already requires a patched runner. The SSD tier is optional and disabled unless `--cache-disk` is supplied.

## Validation

- rebased cleanly as one commit on current `charlie12345/ROCmFPX` `main` (`6bf20cd68`)
- CPU `llama-server` release build completed on the rebased tree
- `tools/server/tests/unit/test_prompt_cache_disk.py`: **6 passed**
- live HY3 + MTP exact-prefix restore: cached TTFP **0.264 s** vs cold **7.33-9.32 s**, with **+176 KiB** RSS
- live HY3 + MTP extension restore: cached TTFP **0.478 s** vs cold **7.66-8.81 s**, with **+152 KiB** RSS
- forced 1536-token context-shift run completed all 300 generated tokens and retained **122/129 (94.57%)** MTP acceptance after the shift
- HermesAgent-20 cache-on run scored **80/100** versus the prior **81/100** control-level result, while the disk tier reached **14.05 GB** and process RSS stayed below **2.01 GiB**

The HermesAgent scenarios are independent, so that run produced zero cache loads; it is a conservative quality/overhead and memory-boundedness check. Exact and extension hit benefits were measured separately in the live smoke tests above.
