### PR TITLE
fix(server): honor per-request speculative n_max/n_min/p_min overrides

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2361,13 +2361,17 @@ private:
 
                         slot.spec_prompt = slot.prompt.tokens.get_text_tokens();
 
+                        const auto & sd = slot.task->params.speculative.draft;
+
                         common_speculative_get_draft_params(spec.get(), slot.id) = {
                             /* .drafting = */ true,
-                            /* .n_max    = */ n_draft_max,
+                            /* .n_max    = */ std::min(n_draft_max, sd.n_max),
                             /* .n_past   = */ slot.prompt.n_tokens(),
                             /* .id_last  = */ slot.sampled,
                             /* .prompt   = */ &slot.spec_prompt,
                             /* .result   = */ &slot.spec_draft,
+                            /* .n_min    = */ sd.n_min,
+                            /* .p_min    = */ sd.p_min,
                         };
 
                         drafting.push_back(&slot);

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -296,9 +296,7 @@ task_params server_task::params_from_json_cmpl(
 
     params.speculative = defaults.speculative;
 
-    // TODO: to keep things simple, we disable speculative parameter adjustments for now
-#if 0
-    // TODO: for now, be able to adjust only the draft-model based speculative parameters
+    // per-request overrides for the draft-model based speculative parameters
     params.speculative.draft.n_min = json_value(data, "speculative.n_min", defaults.speculative.draft.n_min);
     params.speculative.draft.n_max = json_value(data, "speculative.n_max", defaults.speculative.draft.n_max);
     params.speculative.draft.p_min = json_value(data, "speculative.p_min", defaults.speculative.draft.p_min);
@@ -307,6 +305,8 @@ task_params server_task::params_from_json_cmpl(
     params.speculative.draft.n_min = std::max(params.speculative.draft.n_min, 0);
     params.speculative.draft.n_max = std::max(params.speculative.draft.n_max, 0);
 
+    // TODO: to keep things simple, we disable further speculative parameter adjustments for now
+#if 0
     // for debugging and research purposes
     params.speculative.type = common_speculative_type_from_name(json_value(data, "speculative.type", common_speculative_type_to_str(defaults.speculative.type)));
 


### PR DESCRIPTION
## Problem

The server parses `speculative.n_max` / `speculative.n_min` / `speculative.p_min` from each request, but the values never take effect:

- In `tools/server/server-task.cpp`, the draft-param parsing is compiled out behind `#if 0`.
- In `tools/server/server-context.cpp`, the per-sequence `common_speculative_draft_params` only sets `.n_max` (the context-fit cap); `.n_min`/`.p_min` are left at their `-1` sentinels, so `common_speculative`'s `effective_*` helpers always fall back to the startup CLI values.

Net effect: per-request speculative overrides are silently ignored, and the shipped `scripts/rocmfpx-draft-profile.py` (which emits per-request `speculative.*` to back off draft depth at long context) has **no effect**.

## Fix

- Enable the draft-param parsing (the `speculative.type` / ngram overrides stay behind `#if 0` as before).
- Pass `.n_min` / `.p_min` (and a clamped `.n_max = min(n_draft_max, request_n_max)`) into the per-seq draft params.

Two files, +8/-4.

## No regression for the default path

Requests that send nothing default to the startup CLI values, so `effective_n_max/n_min/p_min` resolve to exactly today's behavior. Per-request `n_max` can only *lower* the effective cap (min with the CLI value), which is the intended long-context back-off.

## Verified on hardware (gfx1151 / Strix Halo, MTP draft model)

A request sending `"speculative.n_max": 1` drafts a single position:

```
acceptance rate per position = (0.990, 0.000, 0.000, 0.000, 0.000, 0.000)   # override n_max=1
acceptance rate per position = (0.956, 0.711, 0.511, 0.444, 0.444, 0.289)   # baseline n_max=6
```

confirming the override is now applied end-to-end.

## Notes

- DFlash ignores `n_min`/`p_min` (fixed-block drafting); `n_max` still applies.
- EAGLE3 and draft-mtp honor all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)