### PR TITLE
ggml: default GGML_CUDA_FA_ALL_QUANTS to ON

### DIFF
--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -205,7 +205,14 @@ set   (GGML_CUDA_PEER_MAX_BATCH_SIZE "128" CACHE STRING
 option(GGML_CUDA_NO_PEER_COPY               "ggml: do not use peer to peer copies"            OFF)
 option(GGML_CUDA_NO_VMM                     "ggml: do not try to use CUDA VMM"                OFF)
 option(GGML_CUDA_FA                         "ggml: compile ggml FlashAttention CUDA kernels"  ON)
-option(GGML_CUDA_FA_ALL_QUANTS              "ggml: compile all quants for FlashAttention"     OFF)
+# ROCmFPX default deviates from upstream (OFF): with this off, ggml_cuda_get_best_fattn_kernel()
+# returns NONE for any mismatched K/V cache type pair (e.g. ctk=f16,ctv=q8_0) on CUDA/HIP, and
+# ggml silently falls back to unfused O(n^2) attention instead of erroring. At short context this
+# is just slow; at long context it is catastrophic (confirmed: a 131K-token prompt on ROCm0 with
+# ctk=f16/ctv=q8_0 never finished a single pass in 4.5+ hours with this OFF; fully fixed and
+# verified correct with it ON -- see PR discussion for benchmark numbers). Costs more build time
+# and a larger binary; override with -DGGML_CUDA_FA_ALL_QUANTS=OFF if you never mix KV cache types.
+option(GGML_CUDA_FA_ALL_QUANTS              "ggml: compile all quants for FlashAttention"     ON)
 option(GGML_CUDA_GRAPHS                     "ggml: use CUDA graphs (llama.cpp only)"          ${GGML_CUDA_GRAPHS_DEFAULT})
 option(GGML_CUDA_NCCL                       "ggml: use NVIDIA Collective Comm. Library"       ON)
 set   (GGML_CUDA_COMPRESSION_MODE "size" CACHE STRING


### PR DESCRIPTION
## Summary
Found while benchmarking Laguna-S-2.1 at 262K context on ROCm0 vs Vulkan0 with mismatched KV cache types (ctk=f16, ctv=q8_0, a case worth supporting since quantized V-cache is a legitimate long-context memory tradeoff):

- With `GGML_CUDA_FA_ALL_QUANTS=OFF` (upstream default, unchanged until now), `ggml_cuda_get_best_fattn_kernel()` in `ggml/src/ggml-cuda/fattn.cu` returns `BEST_FATTN_KERNEL_NONE` for any mismatched K/V cache type pair on CUDA/HIP (outside the fork's own Turbo-quant fast path). ggml does not error in this case -- it silently falls back to unfused O(n^2) attention.
- At short context this is just slow (measured: pp4096 50.2 t/s vs 285.7 t/s symmetric-KV baseline, tg4096 14.0 t/s vs 34.6 t/s -- 5.7x/2.5x slower).
- At long context it's catastrophic: a 131,072-token prompt with this config **never completed a single prompt-processing pass in 4.5+ hours** (3+ days of cumulative CPU time across threads, actively computing the whole time, not hung/deadlocked) before I killed it.
- Vulkan0 has no equivalent gate and only sees a mild ~30% pp cost for the same mismatched config at the same depth -- confirming this is HIP/CUDA-kernel-dispatch-specific, not inherent to mixed-precision KV cache.

The kernel code for the mismatched-type case already exists in `fattn.cu` (`FATTN_VEC_CASES_ALL_D(GGML_TYPE_F16, GGML_TYPE_Q8_0)` and friends) and the TILE kernel used for large prompt batches has no additional type restriction of its own -- the whole thing is gated behind this one build flag, which is OFF by upstream default purely to keep build time/binary size down, not because the mismatched-type kernels are unsafe.

## Fix
Flip the fork's default for `GGML_CUDA_FA_ALL_QUANTS` from `OFF` to `ON`. Anyone who wants the smaller/faster build and never mixes KV cache types can still override with `-DGGML_CUDA_FA_ALL_QUANTS=OFF`.

## Test plan
- [x] Fresh from-scratch build on gfx1151 (ROCm 7.14 + Vulkan) from this exact commit, no manual `-D` override -- confirmed `GGML_CUDA_FA_ALL_QUANTS:BOOL=ON` in CMakeCache from the new default alone.
- [x] `test-chat-auto-parser laguna` -> PASS
- [x] `test-llama-archs --arch laguna` -> OK on ROCm0, Vulkan0 (RADV STRIX_HALO), CPU/Meta backends, NMSE vs CPU reference unchanged from pre-fix (~1e-12 to 8.6e-08) -- confirms no correctness regression, only availability of the previously-missing kernel path.
- [x] Regression check on the exact broken case (ROCm0, ctk=f16/ctv=q8_0, pp4096/tg4096): 50.2/14.0 t/s -> 297.1/33.4 t/s, now in line with the symmetric-KV baseline.
- [x] Regression check at the scale that broke (pp131072/tg256): went from never finishing in 4.5+ hours to completing in ~13 minutes at 159.6/36.3 t/s.
- [x] Live production sanity check: served real inference through the Hermes gateway on the rebuilt binary with the standard symmetric (f16/f16) config, confirmed correct output and unchanged decode speed.

## Revert plan
Directory-level backup of pre-fix main taken before this branch existed: `ROCMFPX MAIN PREVIOUS-BUILD-c190e435-pre-fa-all-quants-fix-20260723` (frozen at c190e435, the tip immediately before this change). Also a standard `git revert` of this commit restores the old default if anything regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)