### PR TITLE
scripts: build for the installed GPU, and check what was built

### DIFF
--- a/docs/BUILD-AMD-ARCHITECTURES.md
+++ b/docs/BUILD-AMD-ARCHITECTURES.md
@@ -47,12 +47,18 @@ Then match your GPU to this table:
 | RDNA2 | RX 6700/6800/6900 | `gfx1030`–`gfx1037` | `gfx1030` | `HSA_OVERRIDE_GFX_VERSION=10.3.0` |
 | RDNA3 | RX 7600, RX 7900 XTX/XT/GRE, RX 7800 XT | `gfx1100`–`gfx1102` | `gfx1100` | `HSA_OVERRIDE_GFX_VERSION=11.0.0` |
 | RDNA3.5 | Strix Halo, Ryzen AI MAX+ | `gfx1150`, `gfx1151` | `gfx1151` | `HSA_OVERRIDE_GFX_VERSION=11.5.1` |
-| RDNA4 | RX 9070 XT/GRE | `gfx1200`, `gfx1201` | `gfx1200` | use native `gfx` when ROCm supports it |
+| RDNA4 | RX 9060 XT (Navi 44) | `gfx1200` | `gfx1200` | use native `gfx` when ROCm supports it |
+| RDNA4 | RX 9070 / 9070 XT / AI PRO R9700 (Navi 48) | `gfx1201` | `gfx1201` | must be built as `gfx1201`, see below |
 
 **Tips**
 
 - Sub-variants usually map to the nearest base target (`gfx1035` → `gfx1030`,
   `gfx1102` → `gfx1100`).
+- **RDNA4 is the exception: `gfx1201` is not interchangeable with `gfx1200`.** A
+  `gfx1200` build on a `gfx1201` card links and loads a model, then segfaults or
+  hangs with no error message (issues #18 and #37). The build scripts detect the
+  installed GPU and pick the matching target, and they check the emitted code
+  objects afterwards, so this now fails loudly instead of silently.
 - Published benchmark numbers and regression guards assume **Strix Halo /
   `gfx1151`**.
 - Vega 20 / `gfx906` is an experimental community target. It is not RDNA/CDNA,
@@ -69,12 +75,27 @@ You do not need separate full build scripts for each architecture.
 | Script | Target | Notes |
 |---|---|---|
 | `scripts/build-strix-rocmfp4-mtp.sh` | `gfx1151` | Validated default; includes regression-test binaries |
-| `scripts/build-rdna2.sh` | `gfx1030` | RX 6000 class |
-| `scripts/build-rdna3.sh` | `gfx1100` | RX 7000 class, including RX 7600-class cards |
-| `scripts/build-rdna4.sh` | `gfx1200` | RX 9000 class; requires ROCm support for `gfx1200` device libraries |
+| `scripts/build-rdna2.sh` | `gfx1030` default | RX 6000 class; uses the installed RDNA2 target if it differs |
+| `scripts/build-rdna3.sh` | `gfx1100` default | RX 7000 class; uses the installed RDNA3/3.5 target if it differs |
+| `scripts/build-rdna4.sh` | `gfx1200` default | RX 9000 class; uses `gfx1201` automatically on Navi 48 cards |
 | `scripts/build-gfx906.sh` | `gfx906` | Experimental Vega 20 / MI50 / MI60 community target |
 | `scripts/build-rocmfp4.sh` | any `gfx` | Generic — set `CMAKE_HIP_ARCHITECTURES` yourself |
 | `build-hip.bat` | `gfx1030` | Windows + ROCm 7.x |
+
+Every wrapper honours `CMAKE_HIP_ARCHITECTURES`, so an explicit target always wins:
+
+```bash
+CMAKE_HIP_ARCHITECTURES=gfx1201 scripts/build-rdna4.sh
+```
+
+Two safeguards apply to all of them:
+
+- Changing target reuses nothing: if the build directory was configured for a
+  different `gfx`, it is removed first, because CMake updates the cache while
+  object files for the old target can survive. Set `ROCMFPX_KEEP_STALE_BUILD=1`
+  to keep the directory instead.
+- After the build, the emitted code objects are compared against the requested
+  target and the build fails if they disagree.
 
 Generic example (any single target):
 
@@ -149,8 +170,15 @@ HSA_OVERRIDE_GFX_VERSION=11.0.0 ./build-rdna3/bin/llama-cli -m model.gguf -dev R
 env JOBS=16 scripts/build-rdna4.sh
 ```
 
-Requires a ROCm version with `gfx1200` device libraries. If HIP is not ready yet,
-use the [Vulkan-only path](#vulkan-only-no-hip-arch-needed).
+On a Navi 48 card (RX 9070, 9070 XT, AI PRO R9700) this builds `gfx1201`
+automatically; on Navi 44 (RX 9060 XT) it builds `gfx1200`. Force one with:
+
+```bash
+CMAKE_HIP_ARCHITECTURES=gfx1201 env JOBS=16 scripts/build-rdna4.sh
+```
+
+Requires a ROCm version with device libraries for the target you build. If HIP is
+not ready yet, use the [Vulkan-only path](#vulkan-only-no-hip-arch-needed).
 
 ### Vega 20 / gfx906 — Linux Experimental
 

--- a/scripts/build-gfx906.sh
+++ b/scripts/build-gfx906.sh
@@ -3,5 +3,14 @@
 #
 # This path is provided for community testing on gfx906 hardware. ROCmFP4
 # performance tuning remains validated primarily on Strix Halo / RDNA3.5.
-exec env CMAKE_HIP_ARCHITECTURES=gfx906 BUILD_DIR="${BUILD_DIR:-build-gfx906}" \
-    "$(dirname "$0")/build-rocmfp4.sh"
+#
+# An explicit CMAKE_HIP_ARCHITECTURES always wins; gfx906 is the default.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/rocmfpx-hip-arch.sh"
+
+HIP_ARCH="$(rocmfpx_select_hip_arch gfx906 '^gfx906$')"
+
+exec env CMAKE_HIP_ARCHITECTURES="${HIP_ARCH}" BUILD_DIR="${BUILD_DIR:-build-gfx906}" \
+    "${SCRIPT_DIR}/build-rocmfp4.sh" "$@"

--- a/scripts/build-rdna2.sh
+++ b/scripts/build-rdna2.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
-# RDNA2 build (RX 6000 class) — targets gfx1030
-exec env CMAKE_HIP_ARCHITECTURES=gfx1030 BUILD_DIR="${BUILD_DIR:-build-rdna2}" \
-    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/build-rocmfp4.sh" "$@"
+# RDNA2 build (RX 6000 class).
+#
+# Defaults to gfx1030, but builds for the installed GPU when it is another RDNA2
+# target (gfx1031, gfx1032, gfx1034, ...), because a binary built for the wrong
+# target links and loads and then fails at runtime. An explicit
+# CMAKE_HIP_ARCHITECTURES always wins.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/rocmfpx-hip-arch.sh"
+
+HIP_ARCH="$(rocmfpx_select_hip_arch gfx1030 '^gfx103[0-9a-f]$')"
+
+exec env CMAKE_HIP_ARCHITECTURES="${HIP_ARCH}" BUILD_DIR="${BUILD_DIR:-build-rdna2}" \
+    "${SCRIPT_DIR}/build-rocmfp4.sh" "$@"

--- a/scripts/build-rdna3.sh
+++ b/scripts/build-rdna3.sh
@@ -1,4 +1,16 @@
 #!/usr/bin/env bash
-# RDNA3 build (RX 7000 class) — targets gfx1100
-exec env CMAKE_HIP_ARCHITECTURES=gfx1100 BUILD_DIR="${BUILD_DIR:-build-rdna3}" \
-    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/build-rocmfp4.sh" "$@"
+# RDNA3 build (RX 7000 class).
+#
+# Defaults to gfx1100, but builds for the installed GPU when it is another RDNA3 /
+# RDNA3.5 target (gfx1101, gfx1102, gfx1151, ...), because a binary built for the
+# wrong target links and loads and then fails at runtime. An explicit
+# CMAKE_HIP_ARCHITECTURES always wins.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/rocmfpx-hip-arch.sh"
+
+HIP_ARCH="$(rocmfpx_select_hip_arch gfx1100 '^gfx11[0-9a-f]{2}$')"
+
+exec env CMAKE_HIP_ARCHITECTURES="${HIP_ARCH}" BUILD_DIR="${BUILD_DIR:-build-rdna3}" \
+    "${SCRIPT_DIR}/build-rocmfp4.sh" "$@"

--- a/scripts/build-rdna4.sh
+++ b/scripts/build-rdna4.sh
@@ -1,4 +1,17 @@
 #!/usr/bin/env bash
-# RDNA4 build (RX 9000 class) — targets gfx1200
-exec env CMAKE_HIP_ARCHITECTURES=gfx1200 BUILD_DIR="${BUILD_DIR:-build-rdna4}" \
-    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/build-rocmfp4.sh" "$@"
+# RDNA4 build (RX 9000 class).
+#
+# RDNA4 ships as two AMDGPU targets: gfx1200 (Navi 44) and gfx1201 (Navi 48, which
+# covers the RX 9070 / 9070 XT and the AI PRO R9700). A binary built for the wrong
+# one still links and loads the model, then segfaults or hangs (issues #18, #37), so
+# build for the installed GPU when it is visible. An explicit CMAKE_HIP_ARCHITECTURES
+# always wins, and gfx1200 stays the default when no RDNA4 GPU can be detected.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/rocmfpx-hip-arch.sh"
+
+HIP_ARCH="$(rocmfpx_select_hip_arch gfx1200 '^gfx120[01]$')"
+
+exec env CMAKE_HIP_ARCHITECTURES="${HIP_ARCH}" BUILD_DIR="${BUILD_DIR:-build-rdna4}" \
+    "${SCRIPT_DIR}/build-rocmfp4.sh" "$@"

--- a/scripts/build-rocmfp4.sh
+++ b/scripts/build-rocmfp4.sh
@@ -25,6 +25,7 @@ HIP_EXTRA_FLAGS="${CMAKE_HIP_FLAGS:-}"
 ROCMFP4_DECODE_TUNE="${ROCMFP4_DECODE_TUNE:-stable}"
 DECODE_TUNE_PROFILE="${ROCMFPX_DECODE_TUNE:-$ROCMFP4_DECODE_TUNE}"
 source "$ROOT/scripts/rocmfp4-decode-tune-flags.sh"
+source "$ROOT/scripts/rocmfpx-hip-arch.sh"
 
 if [[ -z "${CMAKE_HIP_ARCHITECTURES:-}" ]]; then
     echo "Using default CMAKE_HIP_ARCHITECTURES=${HIP_ARCH}" >&2
@@ -52,6 +53,8 @@ if [[ -n "$tune_flags" ]]; then
     echo "Decode tuning profile: $DECODE_TUNE_PROFILE"
 fi
 
+rocmfpx_reset_stale_build_dir "$BUILD_DIR" "$HIP_ARCH"
+
 cmake -S "$ROOT" -B "$BUILD_DIR" \
     -DCMAKE_BUILD_TYPE=Release \
     -DGGML_HIP=ON \
@@ -77,6 +80,8 @@ cmake --build "$BUILD_DIR" -j "$JOBS" --target \
     test-backend-ops \
     test-quantize-fns \
     test-quantize-perf
+
+rocmfpx_verify_hip_arch "$BUILD_DIR" "$HIP_ARCH"
 
 echo "Built for ${HIP_ARCH}:"
 echo "  $BUILD_DIR/bin/llama-cli"

--- a/scripts/rocmfpx-hip-arch.sh
+++ b/scripts/rocmfpx-hip-arch.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Shared HIP architecture helpers for the ROCmFPX build scripts. Sourced, not executed.
+#
+# Building for the wrong AMDGPU target does not fail the build: the binary links,
+# loads the model, and then segfaults or hangs with no diagnostic (issues #18, #37).
+# These helpers pick the right target when the machine can tell us, and check the
+# emitted code objects afterwards so a mismatch is loud instead of silent.
+
+# Print every AMDGPU target the machine reports, one per line.
+rocmfpx_detect_hip_archs() {
+    local out=""
+
+    if command -v rocm_agent_enumerator >/dev/null 2>&1; then
+        out="$(rocm_agent_enumerator 2>/dev/null || true)"
+    fi
+    if [[ -z "${out//[[:space:]]/}" ]] && command -v offload-arch >/dev/null 2>&1; then
+        out="$(offload-arch 2>/dev/null || true)"
+    fi
+    if [[ -z "${out//[[:space:]]/}" ]] && command -v rocminfo >/dev/null 2>&1; then
+        out="$(rocminfo 2>/dev/null || true)"
+    fi
+
+    # gfx000 is the placeholder the enumerator prints for the CPU agent.
+    printf '%s\n' "${out}" \
+        | tr ' \t' '\n\n' \
+        | grep -oE '^gfx[0-9a-f]{3,4}[a-z]*$' \
+        | grep -vx 'gfx000' \
+        | sort -u
+}
+
+# rocmfpx_select_hip_arch <fallback> <family regex>
+#
+# An explicit CMAKE_HIP_ARCHITECTURES always wins. Otherwise use the installed GPU
+# when it belongs to this script's family, so a card that needs a sibling target
+# does not silently get the family default. Falls back to the historical value when
+# nothing matching is visible, which keeps offline and cross-compile builds working.
+rocmfpx_select_hip_arch() {
+    local fallback="$1" family="$2" arch
+
+    if [[ -n "${CMAKE_HIP_ARCHITECTURES:-}" ]]; then
+        printf '%s\n' "${CMAKE_HIP_ARCHITECTURES}"
+        return 0
+    fi
+
+    while read -r arch; do
+        [[ -z "${arch}" ]] && continue
+        if [[ "${arch}" =~ ${family} ]]; then
+            if [[ "${arch}" != "${fallback}" ]]; then
+                printf 'Detected %s; building for it instead of the default %s.\n' "${arch}" "${fallback}" >&2
+                printf 'Set CMAKE_HIP_ARCHITECTURES to build for a different target.\n' >&2
+            fi
+            printf '%s\n' "${arch}"
+            return 0
+        fi
+    done < <(rocmfpx_detect_hip_archs)
+
+    printf '%s\n' "${fallback}"
+}
+
+# rocmfpx_reset_stale_build_dir <build dir> <arch>
+#
+# CMake records the new target in CMakeCache.txt when the architecture changes, but
+# object files compiled for the old one can survive in the tree, which is how a cache
+# reading gfx1201 ended up shipping gfx1200 code objects. Changing target requires a
+# full recompile anyway, so start clean. Set ROCMFPX_KEEP_STALE_BUILD=1 to opt out.
+rocmfpx_reset_stale_build_dir() {
+    local build_dir="$1" arch="$2" cached
+
+    [[ -f "${build_dir}/CMakeCache.txt" ]] || return 0
+
+    cached="$(sed -n 's/^CMAKE_HIP_ARCHITECTURES:[^=]*=//p' "${build_dir}/CMakeCache.txt" | head -1)"
+    [[ -n "${cached}" && "${cached}" != "${arch}" ]] || return 0
+
+    if [[ "${ROCMFPX_KEEP_STALE_BUILD:-0}" == "1" ]]; then
+        printf 'Warning: %s was configured for %s, now building %s.\n' "${build_dir}" "${cached}" "${arch}" >&2
+        printf 'ROCMFPX_KEEP_STALE_BUILD=1 is set, so stale code objects may survive.\n' >&2
+        return 0
+    fi
+
+    printf '%s was configured for %s, now building %s.\n' "${build_dir}" "${cached}" "${arch}"
+    printf 'Removing it so no code objects for the old target survive.\n'
+    rm -rf "${build_dir}"
+}
+
+# rocmfpx_verify_hip_arch <build dir> <expected arch>
+#
+# The code objects are what actually run, so check them rather than the cache.
+rocmfpx_verify_hip_arch() {
+    local build_dir="$1" expected="$2" probe found want missing
+
+    command -v strings >/dev/null 2>&1 || return 0
+
+    for probe in "${build_dir}"/bin/libggml-hip.so "${build_dir}"/bin/llama-cli "${build_dir}"/bin/llama-bench; do
+        [[ -f "${probe}" ]] || continue
+
+        found="$(strings "${probe}" 2>/dev/null \
+            | grep -oE 'gfx[0-9a-f]{3,4}[a-z]*' \
+            | grep -vx 'gfx000' \
+            | sort -u | tr '\n' ' ')"
+        [[ -z "${found//[[:space:]]/}" ]] && continue
+
+        # CMAKE_HIP_ARCHITECTURES may be a list; every requested target must be present.
+        missing=""
+        for want in ${expected//[;,]/ }; do
+            [[ -z "${want}" ]] && continue
+            [[ " ${found}" == *" ${want} "* ]] || missing+=" ${want}"
+        done
+
+        if [[ -n "${missing//[[:space:]]/}" ]]; then
+            printf 'ERROR: %s holds code objects for [%s], missing [%s] of the requested %s.\n' \
+                "${probe}" "${found% }" "${missing# }" "${expected}" >&2
+            printf 'Delete %s and build again.\n' "${build_dir}" >&2
+            return 1
+        fi
+
+        printf 'Verified %s code objects in %s\n' "${expected}" "${probe##*/}"
+        return 0
+    done
+
+    return 0
+}


### PR DESCRIPTION
Fixes #18.

## The bug

The generation wrappers passed their target with `exec env CMAKE_HIP_ARCHITECTURES=gfx1200 ...`, which **overrides** the caller's environment instead of deferring to it. So the documented override was silently ignored:

```
$ CMAKE_HIP_ARCHITECTURES=gfx1201 scripts/build-rdna4.sh
  -> build-rocmfp4.sh got CMAKE_HIP_ARCHITECTURES=gfx1200
```

Building for the wrong target does not fail the build. The binary links, loads a model, and then segfaults (#18) or hangs with no output (#37). That is a bad failure mode for something a user cannot see.

`gfx1201` is also not a sub-variant that degrades to `gfx1200`, the way `gfx1035` degrades to `gfx1030` — and Navi 48 (RX 9070, 9070 XT, AI PRO R9700) is the *more common* RDNA4 card, so the `gfx1200` default was wrong for most people running that script. The docs said the two were interchangeable; they are not.

## Changes

New `scripts/rocmfpx-hip-arch.sh` holds the shared helpers, used by all wrappers and by `build-rocmfp4.sh`:

1. **An explicit `CMAKE_HIP_ARCHITECTURES` now wins.** This alone fixes #18.
2. **Otherwise build for the installed GPU** when it belongs to that generation (`build-rdna4.sh` picks `gfx1201` on Navi 48, `build-rdna3.sh` picks `gfx1102`/`gfx1151`, etc). When nothing matching is detected the historical default is used, so **existing gfx1200 / gfx1030 / gfx1100 builds are unchanged**.
3. **A build directory configured for another target is removed first.** CMake writes the new value into `CMakeCache.txt` while object files for the old target survive, which is exactly how the cache in #37 read `gfx1201` while `libggml-hip.so` held `gfx1200` code objects. `ROCMFPX_KEEP_STALE_BUILD=1` opts out.
4. **The emitted code objects are checked against the requested target after the build**, and the build fails if they disagree. Silent wrong-arch binaries were the whole problem.
5. **The build scripts are now executable.** They were committed `100644`, so on a fresh clone the wrapper died with `Permission denied` the moment it exec'd `build-rocmfp4.sh`. This is likely why people ended up hand-rolling cmake invocations.
6. Docs updated for the `gfx1200` / `gfx1201` split.

## Testing (gfx1151, ROCm 7.14)

Selection:

| case | result |
| --- | --- |
| `CMAKE_HIP_ARCHITECTURES=gfx1201 build-rdna4.sh` | `gfx1201` (was `gfx1200`) |
| `build-rdna4.sh`, no override, no RDNA4 GPU | `gfx1200`, unchanged |
| `build-rdna3.sh` on this gfx1151 box | `gfx1151`, announced on stderr |
| `build-rdna2.sh` / `build-gfx906.sh`, no matching GPU | `gfx1030` / `gfx906`, unchanged |

End to end: a full `scripts/build-rdna3.sh` run auto-selected `gfx1151`, built every target, and printed `Verified gfx1151 code objects in libggml-hip.so`. The resulting `llama-cli` reports `version: 168 (81d6fd0)` and the `.so` contains only `gfx1151`. Re-running that same directory with `CMAKE_HIP_ARCHITECTURES=gfx1200` removed it and reconfigured from scratch, leaving no stale `.so`.

Verification: rejects a `gfx1151` build presented as `gfx1201` (the #37 symptom), accepts multi-target lists like `gfx1151;gfx1200` and names only the missing one, and no-ops when no binaries exist yet or `strings` is unavailable.

Not changed: `AMDGPU_TARGETS` is still not passed. `GPU_TARGETS` plus a clean directory on target change covers it, and the post-build check will catch it if that ever stops being true.

AI usage disclosure: analysis, patch and this description were produced with Claude Code assistance; all runs above were executed on the gfx1151 box.