### PR TITLE
cuda: only claim NORM support when rows are contiguous

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -5846,7 +5846,10 @@ static bool ggml_backend_cuda_device_supports_op(ggml_backend_dev_t dev, const g
         case GGML_OP_NORM:
         case GGML_OP_RMS_NORM:
         case GGML_OP_L2_NORM:
-            return true;
+            // These kernels stride over rows but index the innermost dimension directly,
+            // so norm.cu asserts nb00 == ggml_type_size(src0). Claiming support for a
+            // permuted src0 aborts the process instead of falling back to another backend.
+            return ggml_is_contiguous_rows(op->src[0]);
         case GGML_OP_RMS_NORM_BACK:
             return ggml_is_contiguous(op->src[0]);
             break;


### PR DESCRIPTION
## The bug

`ggml_backend_cuda_device_supports_op` returns `true` unconditionally for `GGML_OP_NORM`, `GGML_OP_RMS_NORM` and `GGML_OP_L2_NORM`. The kernels index the innermost dimension directly, so `norm.cu` asserts `nb00 == ggml_type_size(src0)` at lines 425, 468 and 666. Give any of them a permuted `src0` and the process dies:

```
ggml/src/ggml-cuda/norm.cu:425: GGML_ASSERT(nb00 == ts0) failed
```

Advertising support and then aborting is the worst of both worlds — reporting the op as unsupported would let the scheduler run it on another backend, which is what the neighbouring entries (`SILU_BACK`, `RMS_NORM_BACK`) already do.

Upstream llama.cpp guards exactly these three with `ggml_is_contiguous_rows(op->src[0])`. The unconditional `true` has been here since the initial source snapshot (4e8f35a), so this is a fork divergence rather than an upstream issue. This restores the upstream behaviour; `ggml_is_contiguous_rows` already exists in the tree.

## Why it matters beyond the crash

`test-backend-ops -b ROCm0` aborted partway through, so **every op it would have tested after NORM was silently never reported**. The suite could not complete on ROCm at all.

With the guard in place it runs to completion, and that surfaces failures that were being hidden:

- `MUL_MAT_ID` on f16 experts, 7 cases, `ERR ~= 1.0` — that is wrong output, not a precision wobble. `MUL_MAT_ID_FUSION` fails alongside it.
- `ROPE_SET_ROWS` on `q3_0_rocmfpx` / `q6_0_rocmfpx`, the borderline precision misses already known.

**Both are pre-existing and are not touched by this PR.** Running `test-backend-ops -b ROCm0 -o MUL_MAT_ID` (which skips NORM, so it never hit the abort) gives an identical 11 failures on a binary built 2026-07-18, long before any of this weeks work. They deserve their own investigation; this PR only stops them from being invisible.

## Testing (gfx1151, ROCm 7.14)

- `-o NORM` no longer aborts. Non-contiguous cases now report `not supported [ROCm0]`; contiguous cases still run on ROCm and pass.
- Full `test-backend-ops -b ROCm0` now runs to completion.
- No op moved to the CPU in a real graph: with `GGML_SCHED_DEBUG=2` on Qwen3.6-35B-A3B, all 1432 `NORM`/`RMS_NORM`/`L2_NORM` nodes are assigned to `ROCm0` and zero to the CPU. Model norm inputs are contiguous, so the guard never trips in practice.
- Performance unchanged: Qwen3.6-35B-A3B pp128 934.07 / tg32 66.45 (was 923-928 / 64-69); Laguna-S-2.1 pp128 267.41 +/- 22.93 / tg32 34.54 +/- 0.48 (was 266-274 / ~34).

AI usage disclosure: analysis, patch and this description were produced with Claude Code assistance; all runs above were executed on the gfx1151 box.