### PR TITLE
ci: repair WASM WebGPU and scope unavailable runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # allows manual triggering
   push:
     branches:
-      - master
+      - main
     paths: [
       '.github/workflows/build.yml',
       '.github/workflows/build-cmake-pkg.yml',
@@ -73,7 +73,7 @@ jobs:
         with:
           key: macOS-latest-arm64
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build
         id: cmake_build
@@ -109,7 +109,7 @@ jobs:
         with:
           key: macOS-latest-x64
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build
         id: cmake_build
@@ -145,7 +145,7 @@ jobs:
         with:
           key: macOS-latest-arm64-webgpu
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Dawn Dependency
         id: dawn-depends
@@ -181,10 +181,9 @@ jobs:
             os: ubuntu-22.04
           - build: 'arm64'
             os: ubuntu-24.04-arm
-          - build: 's390x'
-            os: ubuntu-24.04-s390x
-          - build: 'ppc64le'
-            os: ubuntu-24.04-ppc64le
+          # Native IBM Z and Power jobs require the IBM Actions P/Z provider.
+          # Keep unavailable vendor labels out of generic PR CI until this
+          # repository completes provider onboarding.
 
     runs-on: ${{ matrix.os }}
 
@@ -194,12 +193,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: ccache
-        if: ${{ matrix.build != 's390x' && matrix.build != 'ppc64le' }}
         uses: ggml-org/ccache-action@v1.2.21
         with:
           key: ubuntu-cpu-${{ matrix.build }}
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build Dependencies
         id: build_depends
@@ -224,14 +222,6 @@ jobs:
           python3 -m pip install --upgrade pip setuptools
           pip3 install ./gguf-py
 
-      - name: Swap Endianness
-        id: endianness
-        if: ${{ matrix.build == 's390x' }}
-        run: |
-          for f in models/*.gguf; do
-            echo YES | python3 gguf-py/gguf/scripts/gguf_convert_endian.py $f big
-          done
-
       - name: Build
         id: cmake_build
         run: |
@@ -248,7 +238,6 @@ jobs:
 
       - name: Test llama2c conversion
         id: llama2c_test
-        if: ${{ matrix.build != 's390x' }}
         run: |
           cd build
           echo "Fetch tokenizer"
@@ -257,15 +246,6 @@ jobs:
           wget https://huggingface.co/karpathy/tinyllamas/resolve/main/stories260K/stories260K.bin
           ./bin/llama-convert-llama2c-to-ggml --copy-vocab-from-model ./tok512.bin --llama2c-model stories260K.bin --llama2c-output-model stories260K.gguf
           ./bin/llama-completion -m stories260K.gguf -p "One day, Lily met a Shoggoth" -n 500 -c 256
-
-      - name: Test llama2c (s390x)
-        id: llama2c_test_s390x
-        if: ${{ matrix.build == 's390x' }}
-        run: |
-          cd build
-          echo "Fetch llama2c big-endian model"
-          wget https://huggingface.co/ggml-org/models/resolve/main/tinyllamas/stories260K-be.gguf
-          ./bin/llama-completion -m stories260K-be.gguf -p "One day, Lily met a Shoggoth" -n 500 -c 256
 
   android-arm64:
     runs-on: ubuntu-latest
@@ -283,7 +263,7 @@ jobs:
         with:
           key: android-arm64
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Set up JDK
         uses: actions/setup-java@v5
@@ -400,7 +380,7 @@ jobs:
         with:
           key: ubuntu-24-webgpu
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Dependencies
         id: depends
@@ -516,7 +496,7 @@ jobs:
         with:
           key: ubuntu-22-hip
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build with native CMake HIP support
         id: cmake_build
@@ -549,7 +529,7 @@ jobs:
         with:
           key: ubuntu-22-musa
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build with native CMake MUSA support
         id: cmake_build
@@ -598,7 +578,7 @@ jobs:
           key: windows-latest-${{ matrix.build }}
           variant: ccache
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Download OpenBLAS
         id: get_openblas
@@ -704,7 +684,7 @@ jobs:
           with:
             key: ubuntu-latest-cuda
             evict-old-files: 1d
-            save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+            save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
         - name: Build with CMake
           # TODO: Remove GGML_CUDA_CUB_3DOT2 flag once CCCL 3.2 is bundled within CTK and that CTK version is used in this project
@@ -738,7 +718,7 @@ jobs:
           key: windows-cuda-${{ matrix.cuda }}
           variant: ccache
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Install Cuda Toolkit
         uses: ./.github/actions/windows-setup-cuda
@@ -819,7 +799,7 @@ jobs:
         with:
           key: ${{ github.job }}
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build
         id: cmake_build
@@ -840,78 +820,11 @@ jobs:
             -DGGML_RPC=ON
           cmake --build build -j ${env:NUMBER_OF_PROCESSORS}
 
-  ubuntu-cpu-riscv64-native:
-    runs-on: ubuntu-24.04-riscv
-
-    steps:
-      - name: Install dependencies
-        run: |
-          # Install necessary packages
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev
-
-          # Set gcc-14 and g++-14 as the default compilers
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
-
-          git lfs install
-
-      - name: Check environment
-        run: |
-          uname -a
-          gcc --version
-          g++ --version
-          ldd --version
-          cmake --version
-          rustc --version
-
-      - name: Clone
-        id: checkout
-        uses: actions/checkout@v6
-
-      - name: ccache
-        uses: ggml-org/ccache-action@afde29e5b5422e5da23cb1f639e8baecadeadfc3 # https://github.com/ggml-org/ccache-action/pull/1
-        with:
-          key: ubuntu-cpu-riscv64-native
-          evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-
-      - name: Build
-        id: cmake_build
-        run: |
-          cmake -B build \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DGGML_OPENMP=OFF \
-            -DLLAMA_BUILD_EXAMPLES=ON \
-            -DLLAMA_BUILD_TOOLS=ON \
-            -DLLAMA_BUILD_TESTS=ON \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DGGML_RPC=ON \
-            -DCMAKE_C_COMPILER=riscv64-linux-gnu-gcc-14 \
-            -DCMAKE_CXX_COMPILER=riscv64-linux-gnu-g++-14
-
-          time cmake --build build --config Release -j $(nproc)
-
-      - name: Test
-        id: cmake_test
-        run: |
-          cd build
-          ctest -L main --verbose --timeout 900
-
-      - name: Test llama2c conversion
-        id: llama2c_test
-        run: |
-          cd build
-          echo "Fetch tokenizer"
-          wget https://huggingface.co/karpathy/tinyllamas/resolve/main/stories260K/tok512.bin
-          echo "Fetch llama2c model"
-          wget https://huggingface.co/karpathy/tinyllamas/resolve/main/stories260K/stories260K.bin
-          ./bin/llama-convert-llama2c-to-ggml --copy-vocab-from-model ./tok512.bin --llama2c-model stories260K.bin --llama2c-output-model stories260K.gguf
-          ./bin/llama-completion -m stories260K.gguf -p "One day, Lily met a Shoggoth" -n 500 -c 256
+  # build-riscv.yml retains the path-scoped RISC-V sanitizer job. Full native
+  # release coverage is deferred until this repo has RISE authorization.
 
 # TODO: simplify the following workflows using a matrix
-# TODO: run lighter CI on PRs and the full CI only on master (if needed)
+# TODO: run lighter CI on PRs and the full CI only on main (if needed)
   ggml-ci-x64-cpu-low-perf:
     runs-on: ubuntu-22.04
 
@@ -925,7 +838,7 @@ jobs:
         with:
           key: ggml-ci-x64-cpu-low-perf
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Dependencies
         id: depends
@@ -951,7 +864,7 @@ jobs:
         with:
           key: ggml-ci-arm64-cpu-low-perf
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Dependencies
         id: depends
@@ -977,7 +890,7 @@ jobs:
         with:
           key: ggml-ci-x64-cpu-high-perf
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Dependencies
         id: depends
@@ -1003,7 +916,7 @@ jobs:
         with:
           key: ggml-ci-arm64-cpu-high-perf
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Dependencies
         id: depends
@@ -1029,7 +942,7 @@ jobs:
         with:
           key: ggml-ci-arm64-cpu-high-perf-sve
           evict-old-files: 1d
-          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Dependencies
         id: depends
@@ -1055,7 +968,7 @@ jobs:
          with:
            key: ggml-ci-arm64-cpu-kleidiai
            evict-old-files: 1d
-           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
        - name: Dependencies
          id: depends
@@ -1068,50 +981,6 @@ jobs:
          run: |
            GG_BUILD_KLEIDIAI=1 GG_BUILD_EXTRA_TESTS_0=1 bash ./ci/run.sh ./tmp/results ./tmp/mnt
 
-  ggml-ci-arm64-cpu-kleidiai-graviton4:
-     runs-on: ah-ubuntu_22_04-c8g_8x
-
-     steps:
-       - name: Clone
-         id: checkout
-         uses: actions/checkout@v6
-
-       - name: Dependencies
-         id: depends
-         run: |
-           set -euxo pipefail
-           sudo apt-get update
-           sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a \
-           apt-get install -y \
-            build-essential \
-            python3-venv \
-            gpg \
-            wget \
-            time \
-            git-lfs
-
-           git lfs install
-
-           # install the latest cmake
-           sudo install -d /usr/share/keyrings
-           wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc \
-            | gpg --dearmor \
-            | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-           echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' \
-            | sudo tee /etc/apt/sources.list.d/kitware.list
-           sudo apt-get update
-           sudo apt-get install -y cmake
-
-       - name: ccache
-         uses: ggml-org/ccache-action@v1.2.21
-         with:
-           key: ggml-ci-arm64-cpu-kleidiai-graviton4
-           evict-old-files: 1d
-           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-
-       - name: Test
-         id: ggml-ci
-         run: |
-           GG_BUILD_KLEIDIAI=1 \
-           GG_BUILD_EXTRA_TESTS_0=1 \
-           bash ./ci/run.sh ./tmp/results ./tmp/mnt
+  # The generic ARM64 KleidiAI job above uses an official GitHub runner.
+  # Exact Graviton4 coverage requires the private Arm runner provider and
+  # should be restored only after that provider is authorized for this repo.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -490,6 +490,7 @@ jobs:
             -G "Ninja" \
             -DCMAKE_BUILD_TYPE=Release \
             -DGGML_WEBGPU=ON \
+            -DGGML_OPENMP=OFF \
             -DLLAMA_OPENSSL=OFF \
             -DEMDAWNWEBGPU_DIR=emdawnwebgpu_pkg
 


### PR DESCRIPTION
## Summary

- disable OpenMP only in the Emscripten WASM/WebGPU CI configure step
- scope four provider-specific jobs that cannot acquire runners in this
  repository out of the generic pull-request matrix
- retain runnable x64, ARM64, HIP, Vulkan, WebGPU, CUDA, Windows, macOS, Android,
  MUSA, RPC, and generic ARM64 KleidiAI coverage
- retain the existing path-scoped RISC-V sanitizer definition and defer the
  full native release job until this repository has RISE runner authorization
- align this workflow's push branch and cache-save refs with the repository's
  actual default branch, `main`
- leave ROCmFP2 PR #42 and all production source code unchanged

## Root cause

The `ubuntu-24-webgpu-wasm` job links with `-sMEMORY64=1`, but OpenMP causes
CMake/Emscripten to inject explicit `wasm32-emscripten` OpenMP and system
archives. `wasm-ld` correctly rejects those wasm32 objects in a wasm64 link.

## Upstream provenance and credit

The first commit is the minimal one-line port of the fix from ggml-org/llama.cpp PR
[#25943](https://github.com/ggml-org/llama.cpp/pull/25943), merged upstream as
[`7cdd557f7680`](https://github.com/ggml-org/llama.cpp/commit/7cdd557f76800b5a84ddee2bff6f20178a3e31fe)
and authored by Reese Levine. The local commit includes GitHub's
`Co-authored-by` trailer for Reese.

Upstream currently runs the same `emsdk latest`, Dawn `v20260317.182325`, and
MEMORY64 configuration successfully with OpenMP disabled:
[passing upstream WASM job](https://github.com/ggml-org/llama.cpp/actions/runs/30450948862/job/90572590682).

The second commit adopts upstream's provider-scoping direction from
ggml-org/llama.cpp PR
[#23675](https://github.com/ggml-org/llama.cpp/pull/23675), merged as
[`302e2c2652ba`](https://github.com/ggml-org/llama.cpp/commit/302e2c2652ba42992f6df581a191a076151fce94)
and authored by Georgi Gerganov. Unlike upstream, this fork does not yet have
RISE authorization, so the full native RISC-V release job is deferred rather
than moved into the dedicated workflow. The commit also records the original
provider work for IBM Actions P/Z
([#15925](https://github.com/ggml-org/llama.cpp/pull/15925)), RISE RISC-V
([#21263](https://github.com/ggml-org/llama.cpp/pull/21263)), and Arm Graviton
([#17021](https://github.com/ggml-org/llama.cpp/pull/17021)).

## Scope and impact

The diff is confined to `.github/workflows/build.yml`. It does not modify
runtime code, ROCm, Vulkan, CPU behavior, GGUF layout, quantization formats, or
the frozen ROCmFP2 codebook.

The four removed generic checks have never acquired a runner in this repository
and repeatedly remain queued until GitHub cancels the workflow after 24 hours:

- IBM Z (`ubuntu-24.04-s390x`)
- IBM Power (`ubuntu-24.04-ppc64le`)
- RISE RISC-V (`ubuntu-24.04-riscv`)
- private Arm Graviton4 (`ah-ubuntu_22_04-c8g_8x`)

This does not disguise failures with `continue-on-error` or skip a failing test.
It makes generic PR CI match the runner providers actually authorized for this
repository. Exact IBM and Graviton coverage can be restored when their provider
apps are installed. The existing RISC-V sanitizer job remains defined in
`.github/workflows/build-riscv.yml` and scoped to RISC-V backend changes, but it
also requires RISE runner authorization; the removed full native release job is
therefore explicitly deferred. The runnable official GitHub ARM64 KleidiAI job
remains enabled.

## Validation

- `git diff --check`
- YAML parse passed
- structural assertions passed for the retained job matrix, WASM OpenMP flag,
  default branch refs, and removed unavailable labels
- the final-head WASM job passed and its link audit found no wasm32 OpenMP
  archives in the MEMORY64 build
- the branch changes only `.github/workflows/build.yml`
- [GitHub Actions run 30472581460](https://github.com/charlie12345/ROCmFPX/actions/runs/30472581460):
  27 jobs completed successfully and zero jobs failed
- Windows CUDA remained actively compiling after a multi-hour run; the
  repository owner explicitly accepted that single still-running check as a
  merge exception. It is recorded as **in progress**, not claimed as passed.

## Merge and rollback

Use **Create a merge commit** only after every applicable check is green. A
verified pre-refactor Git bundle and safety ref are retained locally. If a
regression appears, revert only this PR's merge with:

```bash
git revert -m 1 <ci-fix-merge-sha>
```

PR #42 remains draft and unchanged until this repair is merged and its branch
is refreshed from `main`.
