### PR TITLE
laguna: publish layer inputs so DFlash/EAGLE3 extraction works

### DIFF
--- a/src/models/laguna.cpp
+++ b/src/models/laguna.cpp
@@ -171,6 +171,11 @@ llama_model_laguna::graph::graph(const llama_model & model, const llm_graph_para
     const float kq_scale = 1.0f / sqrtf(float(n_embd_head));
 
     for (int il = 0; il < n_layer; ++il) {
+        // publish the layer input so DFlash/EAGLE3-style extraction can read it
+        // (mirrors qwen35moe.cpp / llama.cpp / gemma4.cpp; required by
+        //  llm_graph_result::set_outputs -> GGML_ASSERT(t_layer_inp[il] != nullptr))
+        res->t_layer_inp[il] = inpL;
+
         const bool    is_swa_il   = hparams.is_swa(il);
         const int64_t n_head_il   = hparams.n_head(il);
         const int64_t n_head_kv_il = hparams.n_head_kv(il);


### PR DESCRIPTION
One line in `laguna.cpp`'s layer loop, mirroring seven other arches.

### Problem

`llama_set_embeddings_layer_inp(ctx_tgt, id, true)` records the extraction request, but `laguna.cpp` never populated `res->t_layer_inp[il]`. The server starts and answers `/health`, then the first generation request aborts:

```
src/llama-graph.cpp:997: GGML_ASSERT(t_layer_inp[il] != nullptr && "layer input tensor is null") failed
```

So any DFlash or EAGLE3-style draft against a `laguna` target is unusable.

### Fix

```diff
     for (int il = 0; il < n_layer; ++il) {
+        res->t_layer_inp[il] = inpL;
+
         const bool    is_swa_il   = hparams.is_swa(il);
```

Already done this way in `qwen35moe.cpp`, `llama.cpp`, `gemma4.cpp`, `qwen3.cpp`, `qwen3moe.cpp`, `openai-moe.cpp`, and `qwen35.cpp`.

### Result

With this plus #(dflash tensor support), a DFlash draft runs end-to-end against `Laguna-S-2.1` (48 blocks, `n_embd` 3072) on gfx1151 / ROCm 7.2.3:

| config | decode |
|---|---|
| no draft | 32.7 / 33.3 t/s |
| `--spec-draft-n-max 4` | **43.1 / 43.5 t/s** |

and 2.01x at 21.5k context. GSM8K n=500 unchanged (0.926 vs 0.924).

This PR is independently safe — it only publishes a tensor that was already allocated, and arches that don't request extraction are unaffected. Context in #44.