### PR TITLE
Fix static HIP link failure in build-rocmfp4-rocm714-local.sh

### DIFF
--- a/scripts/build-rocmfp4-rocm714-local.sh
+++ b/scripts/build-rocmfp4-rocm714-local.sh
@@ -66,12 +66,19 @@ echo "Using clang++: $CLANGXX"
 # ── Configure ────────────────────────────────────────────────────────
 echo "Configuring build..."
 
+# ggml-hip's CMakeLists falls back to $ENV{ROCM_PATH} / /opt/rocm when this is
+# unset, which pulls in a second, mismatched HIP runtime alongside the local
+# toolchain at link time. Pin it so only $ROCM_LOCAL_PATH is ever resolved.
+export ROCM_PATH="$ROCM_LOCAL_PATH"
+export HIP_PATH="$ROCM_LOCAL_PATH"
+
 cmake -S "$ROOT" -B "$BUILD_DIR" \
     -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_C_COMPILER="$CLANG" \
     -DCMAKE_CXX_COMPILER="$CLANGXX" \
     -DCMAKE_CXX_FLAGS="-I${ROCM_LOCAL_PATH}/include" \
+    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DGGML_HIP=ON \
     -DGGML_HIP_FORCE_MMQ=ON \
     -DGGML_HIP_ROCWMMA_FATTN=OFF \
@@ -162,11 +169,6 @@ else
     echo "patchelf was not available; set LD_LIBRARY_PATH at runtime:"
     echo "  LD_LIBRARY_PATH=${ROCM_LOCAL_PATH}/lib/llvm/lib:${ROCM_LOCAL_PATH}/lib:${ROCM_LOCAL_PATH}/lib/rocm_sysdeps/lib $BUILD_DIR/bin/llama-cli -m model.gguf -dev ROCm0 -ngl 999"
 fi
-
-# ── Verify ───────────────────────────────────────────────────────────
-echo ""
-echo "Verification:"
-ldd "$BUILD_DIR/bin/llama-cli" 2>/dev/null | grep -E "not found|libomp|libamdhip|librocblas|libhipblas" | head -10 || echo "  (no issues)"
 
 # ── Verify ───────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

`scripts/build-rocmfp4-rocm714-local.sh` (added in #17) fails to link with:

```
ld.lld: error: relocation R_X86_64_32 cannot be used against local symbol; recompile with -fPIC
>>> defined in ggml/src/ggml-hip/libggml-hip.a(wkv.cu.o)
```

**Root cause**: `ggml/src/CMakeLists.txt` only sets `POSITION_INDEPENDENT_CODE ON` when `BUILD_SHARED_LIBS=ON`. This is the only build script in `scripts/` that passes `-DBUILD_SHARED_LIBS=OFF` (for a fully static, self-contained binary), so the HIP static objects in `libggml-hip.a` get compiled non-PIC — but the toolchain defaults to linking a PIE executable, which requires PIC objects.

Separately, `ggml/src/ggml-hip/CMakeLists.txt` falls back to `$ENV{ROCM_PATH}` / `/opt/rocm` when `ROCM_PATH` is unset. On a machine with a system-wide ROCm install at `/opt/rocm`, this caused CMake to resolve `hip`/`hipblas`/`rocblas` from the system install *in addition to* the local nightly toolchain passed via `-DCMAKE_PREFIX_PATH`/`-DROCM_DIR`, linking two different HIP runtime versions into the same binary.

## Fix

- Add `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` to the cmake configure call, forcing PIC regardless of `BUILD_SHARED_LIBS`.
- Export `ROCM_PATH`/`HIP_PATH` pointing at the local toolchain before configuring, so `ggml-hip`'s CMakeLists doesn't fall back to a system ROCm install.
- Remove a duplicated "Verify" block at the end of the script.

## Test plan

Tested on a machine with 4x AMD Radeon AI Pro R9700 (gfx1201) and a pre-existing system ROCm 7.2.3 install at `/opt/rocm`, using the ROCm 7.14.0a20260624 TheRock nightly tarball.

- [x] Clean build from scratch (`rm -rf build-rdna4-rocm714 && env JOBS=48 scripts/build-rocmfp4-rocm714-local.sh`) completes with exit 0, no link errors.
- [x] Confirmed `-fPIC` is present in the freshly-generated HIP compile command (`ninja -t commands ... wkv.cu.o | grep fPIC`) — rules out the fix riding a stale cmake cache.
- [x] Confirmed the fresh link line for `llama-cli` only references the local ROCm 7.14 toolchain (`.../rocm-7.14.../lib/libamdhip64.so...`) with no `/opt/rocm-7.2.3` entries in the rpath or link inputs, unlike the pre-fix build.
- [x] `test-backend-ops -o ADD` (GPU-vs-CPU correctness comparison): 99/99 passed on all 4 ROCm devices, all 4 Vulkan devices, and CPU.
- [x] Full `test-backend-ops` suite: 13,654/13,671 correctness cases passed before hitting an unrelated timeout. Remaining failures/OOMs are pre-existing (EXPM1 NaN/Inf edge case, small SET_ROWS tolerance overage on `q3_0_rocmfpx`/`q6_0_rocmfpx`, a MUL_MAT_ID MoE-routing mismatch, and VRAM contention from another live process on the shared test machine) — none are touched by this change, which only modifies cmake flags and env vars, not any kernel/op code.

Note: `ldd` (without `LD_LIBRARY_PATH`) still resolves `libamdhip64`/`hipblas`/`rocblas`/`hipblaslt` from `/opt/rocm` at *load time*, since RUNPATH is consulted after `ld.so.cache`. This PR fixes *link-time* resolution (which library CMake finds and links against); the script's existing `patchelf`-based rpath rewrite (or the documented `LD_LIBRARY_PATH` fallback) is still needed to force *load-time* resolution to the local toolchain.