### PR TITLE
server: add --spec-mtp-strict-qwen for exact greedy Qwen35/Qwen35MoE MTP

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -3392,6 +3392,14 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER}).set_env("LLAMA_ARG_SPEC_MTP_STRICT"));
     add_opt(common_arg(
+        {"--spec-mtp-strict-qwen"},
+        {"--no-spec-mtp-strict-qwen"},
+        "use boundary-safe multi-row verification with bounded recurrent rollback for exact greedy Qwen35/Qwen35MoE MTP output; requires one slot/sequence (default: disabled)",
+        [](common_params & params, bool value) {
+            params.speculative.mtp_strict_qwen = value;
+        }
+    ).set_spec().set_examples({LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_MTP_STRICT_QWEN"));
+    add_opt(common_arg(
         {"--spec-draft-hf", "-hfd", "-hfrd", "--hf-repo-draft"}, "<user>/<model>[:quant]",
         "Same as --hf-repo, but for the draft model (default: unused)",
         [](common_params & params, const std::string & value) {
@@ -3564,6 +3572,9 @@ common_params_context common_params_parser_init(common_params & params, llama_ex
         {"--spec-draft-n-max"}, "N",
         string_format("number of tokens to draft for speculative decoding (default: %d)", params.speculative.draft.n_max),
         [](common_params & params, int value) {
+            if (value < 0) {
+                throw std::invalid_argument("invalid value");
+            }
             params.speculative.draft.n_max = value;
         }
     ).set_spec().set_examples({LLAMA_EXAMPLE_SPECULATIVE, LLAMA_EXAMPLE_LOOKUP, LLAMA_EXAMPLE_SERVER, LLAMA_EXAMPLE_CLI}).set_env("LLAMA_ARG_SPEC_DRAFT_N_MAX"));

--- a/common/common.h
+++ b/common/common.h
@@ -347,6 +347,7 @@ struct common_params_speculative_ngram_cache {
 struct common_params_speculative {
     std::vector<enum common_speculative_type> types = { COMMON_SPECULATIVE_TYPE_NONE };
     bool mtp_strict = true;
+    bool mtp_strict_qwen = false;
 
     // used by Simple, MTP, Eagle3, etc. - all methods that require some kind of draft model
     common_params_speculative_draft draft;
@@ -366,8 +367,7 @@ struct common_params_speculative {
         bool needs_rs_seq = std::any_of(types.begin(), types.end(), [&](auto t) {
             return t == COMMON_SPECULATIVE_TYPE_DRAFT_MTP || t == COMMON_SPECULATIVE_TYPE_DRAFT_EAGLE3 || t == COMMON_SPECULATIVE_TYPE_DRAFT_DFLASH;
         });
-
-        return needs_rs_seq ? draft.n_max : 0u;
+        return needs_rs_seq ? (uint32_t) std::max<int32_t>(0, draft.n_max) : 0u;
     }
 };
 

--- a/tests/test-arg-parser.cpp
+++ b/tests/test-arg-parser.cpp
@@ -106,6 +106,14 @@ int main(void) {
     argv = {"binary_name", "--no-spec-mtp-strict"};
     assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_EMBEDDING));
 
+    // Qwen strict MTP control is server/CLI-only
+    argv = {"binary_name", "--spec-mtp-strict-qwen"};
+    assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_EMBEDDING));
+
+    // a negative draft maximum must not wrap when sizing recurrent rollback state
+    argv = {"binary_name", "--spec-draft-n-max", "-1"};
+    assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_SPECULATIVE));
+
     // negated arg
     argv = {"binary_name", "--no-mmap"};
     assert(false == common_params_parse(argv.size(), list_str_to_char(argv).data(), params, LLAMA_EXAMPLE_COMMON));
@@ -146,6 +154,29 @@ int main(void) {
         argv = {"binary_name", "--spec-mtp-strict"};
         assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), strict_params, LLAMA_EXAMPLE_SERVER));
         assert(strict_params.speculative.mtp_strict == true);
+
+        assert(strict_params.speculative.mtp_strict_qwen == false);
+        strict_params.speculative.types = { COMMON_SPECULATIVE_TYPE_DRAFT_MTP };
+        strict_params.speculative.draft.n_max = 6;
+        assert(strict_params.speculative.need_n_rs_seq() == 6);
+        strict_params.speculative.draft.n_max = -1;
+        assert(strict_params.speculative.need_n_rs_seq() == 0);
+        strict_params.speculative.draft.n_max = 6;
+
+        argv = {"binary_name", "--spec-mtp-strict-qwen"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), strict_params, LLAMA_EXAMPLE_SERVER));
+        assert(strict_params.speculative.mtp_strict_qwen == true);
+        assert(strict_params.speculative.need_n_rs_seq() == 6);
+
+        argv = {"binary_name", "--no-spec-mtp-strict-qwen"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), strict_params, LLAMA_EXAMPLE_SERVER));
+        assert(strict_params.speculative.mtp_strict_qwen == false);
+        assert(strict_params.speculative.need_n_rs_seq() == 6);
+
+        common_params cli_strict_params;
+        argv = {"binary_name", "-m", "model_file.gguf", "--spec-mtp-strict-qwen"};
+        assert(true == common_params_parse(argv.size(), list_str_to_char(argv).data(), cli_strict_params, LLAMA_EXAMPLE_CLI));
+        assert(cli_strict_params.speculative.mtp_strict_qwen == true);
     }
 
     // multi-value args (CSV)

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -713,6 +713,7 @@ private:
 
     common_speculative_ptr spec;
     bool strict_hy3_mtp_verification = false;
+    bool strict_qwen_mtp_verification = false;
 
     bool add_bos_token = true;
 
@@ -801,15 +802,25 @@ private:
 
         {
             char model_arch[32] = {};
-            const bool is_hy3 =
-                llama_model_meta_val_str(model_tgt, "general.architecture", model_arch, sizeof(model_arch)) >= 0 &&
-                strcmp(model_arch, "hy_v3") == 0;
+            const bool has_model_arch =
+                llama_model_meta_val_str(model_tgt, "general.architecture", model_arch, sizeof(model_arch)) >= 0;
+            const bool is_hy3 = has_model_arch && strcmp(model_arch, "hy_v3") == 0;
+            const bool is_qwen35 =
+                has_model_arch &&
+                (strcmp(model_arch, "qwen35") == 0 || strcmp(model_arch, "qwen35moe") == 0);
             const bool has_mtp =
                 std::find(params_base.speculative.types.begin(),
                           params_base.speculative.types.end(),
                           COMMON_SPECULATIVE_TYPE_DRAFT_MTP) != params_base.speculative.types.end();
 
             strict_hy3_mtp_verification = is_hy3 && has_mtp && params_base.speculative.mtp_strict;
+            strict_qwen_mtp_verification = is_qwen35 && has_mtp && params_base.speculative.mtp_strict_qwen;
+
+            if (params_base.speculative.mtp_strict_qwen && !strict_qwen_mtp_verification) {
+                SRV_ERR("%s", "--spec-mtp-strict-qwen requires a qwen35 or qwen35moe target with draft-mtp enabled\n");
+                return false;
+            }
+
             if (strict_hy3_mtp_verification) {
                 if (params_base.n_parallel != 1) {
                     SRV_ERR("%s", "HY3 strict MTP requires a single server slot; restart with -np 1 or use --no-spec-mtp-strict\n");
@@ -818,6 +829,20 @@ private:
                 SRV_WRN("%s", "HY3 strict MTP: single-row target verification is enabled for exact greedy output and may reduce throughput\n");
             } else if (is_hy3 && has_mtp) {
                 SRV_WRN("%s", "HY3 MTP strict verification is disabled; greedy output may diverge from no-spec decoding\n");
+            }
+
+            if (strict_qwen_mtp_verification) {
+                if (params_base.n_parallel != 1) {
+                    SRV_ERR("%s", "Qwen strict MTP requires a single server slot/sequence; restart with -np 1 or use --no-spec-mtp-strict-qwen\n");
+                    return false;
+                }
+                if (llama_n_rs_seq(ctx_tgt) < (uint32_t) params_base.speculative.draft.n_max) {
+                    SRV_ERR("%s", "Qwen strict MTP requires bounded recurrent rollback covering the full draft\n");
+                    return false;
+                }
+                SRV_WRN("%s", "Qwen strict MTP: boundary-safe multi-row verification with bounded recurrent rollback is enabled for exact greedy output\n");
+            } else if (is_qwen35 && has_mtp) {
+                SRV_WRN("%s", "Qwen MTP strict verification is disabled; greedy output may diverge from no-spec decoding (enable --spec-mtp-strict-qwen)\n");
             }
         }
 
@@ -978,6 +1003,12 @@ private:
         slots.clear();
 
         ctx_tgt_seq_rm_type = common_context_can_seq_rm(ctx_tgt);
+        if (strict_qwen_mtp_verification &&
+            (ctx_tgt_seq_rm_type != COMMON_CONTEXT_SEQ_RM_TYPE_RS ||
+             llama_n_rs_seq(ctx_tgt) < (uint32_t) params_base.speculative.draft.n_max)) {
+            SRV_ERR("%s", "Qwen strict MTP requires bounded rollback covering the full draft\n");
+            return false;
+        }
         if (ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_NO) {
             SRV_WRN("%s", "speculative decoding not supported by this context\n");
         }
@@ -2400,7 +2431,24 @@ private:
                 const bool use_ckpt_tgt = ctx_tgt_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
                 const bool use_ckpt_dft = ctx_dft_seq_rm_type == COMMON_CONTEXT_SEQ_RM_TYPE_FULL;
 
-                const int n_draft_max = slot.get_n_draft_max();
+                int n_draft_max = slot.get_n_draft_max();
+
+                if (strict_qwen_mtp_verification) {
+                    // Dense-attention KV width is padded in 256-cell blocks.
+                    // A verification batch that straddles a block makes its
+                    // earlier rows use a wider ROCm reduction than serial
+                    // decoding and can change greedy output through rounding.
+                    // Count the sampled target row plus drafts and cap the
+                    // draft so the entire verification stays in one block.
+                    if (slot.truncated || slot.prompt.tokens.pos_next() < 0) {
+                        n_draft_max = 0;
+                    } else {
+                        constexpr uint32_t kv_pad = 256;
+                        const uint32_t rows_to_boundary =
+                            kv_pad - ((uint32_t) slot.prompt.tokens.pos_next() % kv_pad);
+                        n_draft_max = std::min(n_draft_max, std::max(0, (int) rows_to_boundary - 1));
+                    }
+                }
 
                 if (n_draft_max > 0) {
                     GGML_ASSERT(slot.can_speculate());
@@ -2838,9 +2886,26 @@ private:
 
                         // [TAG_PROMPT_LOGITS]
                         if (n_past == slot.task->n_tokens() && n_past > 0) {
-                            SLT_WRN(slot, "need to evaluate at least 1 token for each active slot (n_past = %d, task.n_tokens() = %d)\n", n_past, slot.task->n_tokens());
-                            n_past--;
-                            SLT_WRN(slot, "n_past was set to %d\n", n_past);
+                            if (strict_qwen_mtp_verification) {
+                                // Recurrent prompt state stores only the selected
+                                // row, not the rollback snapshot history. Replaying
+                                // one token after an exact cache hit would select a
+                                // snapshot that was never restored. Clear all
+                                // speculative state and reprocess the prompt so
+                                // the target and MTP boundary states stay paired.
+                                SLT_WRN(slot,
+                                        "prompt cache cold fallback: reason=strict-qwen-exact-hit cached_tokens=%d request_tokens=%d\n",
+                                        n_past, slot.task->n_tokens());
+                                n_past = 0;
+                                slot.spec_draft.clear();
+                                slot.spec_i_batch.clear();
+                                slot.spec_ckpt.clear();
+                                common_speculative_set_state(spec.get(), slot.id, {});
+                            } else {
+                                SLT_WRN(slot, "need to evaluate at least 1 token for each active slot (n_past = %d, task.n_tokens() = %d)\n", n_past, slot.task->n_tokens());
+                                n_past--;
+                                SLT_WRN(slot, "n_past was set to %d\n", n_past);
+                            }
                         }
 
                         slot.n_prompt_tokens_cache = n_past;


### PR DESCRIPTION
Adds the `--spec-mtp-strict-qwen` flag reported missing from `main` — it existed only in a local tree and was never committed, so `llama-server` from a clean clone rejects it.

## What it does

Opt-in strict verification for `draft-mtp` speculative decoding on `qwen35`/`qwen35moe` targets, mirroring the existing `--spec-mtp-strict` for `hy_v3`.

Without it, speculative greedy output can diverge from non-speculative greedy decoding: dense-attention KV width is padded in 256-cell blocks, so a verification batch straddling a boundary uses a wider reduction for its earlier rows than serial decoding, and the rounding difference can change the sampled token. With it enabled, the draft is capped so verification never crosses a KV block boundary, and an exact prompt-cache hit falls back to a cold reprocess so target and MTP boundary states stay paired.

## Safety

- Gated on `(qwen35|qwen35moe) && draft-mtp && flag` — **inert for every other model** and for non-MTP speculation.
- Default **disabled**, so no existing behaviour changes.
- Requires `-np 1` and recurrent rollback covering the full draft; both validated at startup with an explicit error rather than silently degrading.

## Cost

~0.5% decode throughput on a 35B-A3B MoE (95.5 vs 96.1 t/s) in exchange for bit-identical greedy output.

## Also included

Rejects a negative `--spec-draft-n-max` and clamps `need_n_rs_seq()` so the value cannot wrap to a huge unsigned when sizing recurrent rollback state. Covered by new `test-arg-parser` cases.

## Verification

- Branched from current `main` (`b41ce12ea`), not an older base.
- Clean CPU build, zero errors/warnings.
- `test-arg-parser`: all tests OK.
- Flag appears in `--help`; negative `n_max` correctly rejected.

Deliberately scoped: unrelated changes present in the author's local tree (an `n_discard` clamp and a speculative error-handling rewrite) were **excluded** because they are ungated and would alter behaviour for all speculative-decoding users. They can follow separately.