### PR TITLE
server: correct accepted tokens when need draft token replay (port of upstream #26320)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -73,6 +73,7 @@ struct server_slot {
     llama_tokens spec_prompt;
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
+    bool spec_is_replay = false;
 
     // TODO: move members that belong to the task (such as `generated_text`, `has_new_line`) to task_results_state
     //       see https://github.com/ggml-org/llama.cpp/pull/18283#issuecomment-3710175837
@@ -216,6 +217,8 @@ struct server_slot {
 
     void reset() {
         SLT_DBG(*this, "%s", "\n");
+
+        spec_is_replay = false;
 
         n_prompt_tokens_cache = 0;
 
@@ -3449,6 +3452,7 @@ private:
                             }
 
                             // partial acceptance is not supported by the context -> truncate the draft and restore the state
+                            slot.spec_is_replay = true;
                             slot.spec_draft = std::move(accepted);
 
                             const auto & ckpt = slot.spec_ckpt;
@@ -3503,16 +3507,22 @@ private:
 
                 const auto ids = std::move(slot.spec_draft);
 
+                size_t n_accepted = ids.size() - 1;
+                if (slot.spec_is_replay && n_accepted > 0) {
+                    n_accepted--;
+                }
+                slot.spec_is_replay = false;
+
                 slot.t_token_generation = std::max<int64_t>(1, t_current - slot.t_start_generation) / 1e3;
 
                 // update how many tokens out of those tested were accepted
-                slot.n_draft_accepted += ids.size() - 1;
+                slot.n_draft_accepted += n_accepted;
                 slot.n_draft_verif_steps += 1;
 
                 if (slot.n_accepted_per_pos.empty()) {
                     slot.n_accepted_per_pos.resize(std::max(1, params_base.speculative.draft.n_max), 0);
                 }
-                for (size_t i = 0; i < ids.size() - 1 && i < slot.n_accepted_per_pos.size(); ++i) {
+                for (size_t i = 0; i < n_accepted && i < slot.n_accepted_per_pos.size(); ++i) {
                     slot.n_accepted_per_pos[i]++;
                 }
 


### PR DESCRIPTION
Ports [ggml-org/llama.cpp#26320](https://github.com/ggml-org/llama.cpp/pull/26320) (upstream commit `000547513`) by **Ruixiang Wang**, co-authored by **Georgi Gerganov**.

## The bug

When the context cannot do partial draft acceptance, the draft is truncated and the state restored — and the replayed token was then counted as an accepted draft token. Every replay inflated `n_draft_accepted` and `n_accepted_per_pos` by one.

This tree still had the uncorrected form:

```cpp
slot.n_draft_accepted += ids.size() - 1;
```

## Why it matters here

Those counters produce the `draft acceptance`, `mean acceptance length` and `acceptance rate per position` values the server logs. Those are exactly the numbers used to tune `--spec-draft-n-max` and `--spec-draft-p-min` for MTP, so tuning was being done against optimistic data.

## The fix

A `spec_is_replay` flag on the slot — cleared in `reset()`, set on the truncate-and-restore path, consumed when tallying acceptance.

**Only reported metrics change. Generated output and decode throughput are unaffected.**

## Note on the port

This repository shares no git ancestry with `ggml-org/llama.cpp` (it begins at commit `ebee2649a "Initial commit"`, a published source snapshot), so `git cherry-pick 000547513` cannot apply cleanly — `server-context.cpp` has diverged. The change was applied by hand at the four equivalent sites; the resulting diff is semantically identical to upstream's.

## Verification

- Branched from current `main` (`41db2f9eb`)
- Diff is 12 insertions / 2 deletions, confined to the fix
- Clean build, 0 errors/warnings
- `test-arg-parser` passes
- Measured on a 35B-A3B MoE with `draft-mtp`: throughput unchanged (~1.4x speedup preserved); reported per-position acceptance shifts, as expected when the over-count is removed