### PR TITLE
server: restore speculative state alongside spec checkpoints (fixes MTP abort on checkpoint targets)

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -74,6 +74,10 @@ struct server_slot {
     std::vector<int32_t> spec_i_batch;
     common_prompt_checkpoint spec_ckpt;
 
+    // speculative-impl state (e.g. MTP boundary hidden rows) snapshotted together with
+    // spec_ckpt, so that a checkpoint restore can also rewind the draft bookkeeping
+    std::vector<uint8_t> spec_state;
+
     // TODO: move members that belong to the task (such as `generated_text`, `has_new_line`) to task_results_state
     //       see https://github.com/ggml-org/llama.cpp/pull/18283#issuecomment-3710175837
     std::unique_ptr<const server_task> task;
@@ -231,6 +235,7 @@ struct server_slot {
             spec_draft.clear();
             spec_i_batch.clear();
             spec_ckpt.clear();
+            spec_state.clear();
         }
         generated_tokens.clear();
         generated_token_probs.clear();
@@ -2418,6 +2423,13 @@ private:
                                 llama_memory_seq_pos_min(llama_get_memory(ctx_tgt), slot.id),
                                 llama_memory_seq_pos_max(llama_get_memory(ctx_tgt), slot.id));
 
+                        // snapshot the speculative-impl state (MTP boundary rows) at the
+                        // same point as the KV checkpoint, so both can be rewound together
+                        if (common_speculative_state_required(spec.get())) {
+                            slot.spec_state.clear();
+                            common_speculative_get_state(spec.get(), slot.id, slot.spec_state);
+                        }
+
                         if (use_ckpt_dft) {
                             slot.spec_ckpt.update_dft(ctx_dft.get(), slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY | LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
                         }
@@ -3420,6 +3432,12 @@ private:
 
                             slot.prompt.tokens.keep_first(ckpt.n_tokens);
                             slot.smpl = std::move(smpl_save);
+
+                            // rewind the speculative-impl state (MTP boundary rows) to match
+                            // the restored KV; the replayed batch re-runs process() from here
+                            if (!slot.spec_state.empty()) {
+                                common_speculative_set_state(spec.get(), slot.id, slot.spec_state);
+                            }
 
                             continue;
                         }


### PR DESCRIPTION
## Problem

MTP (`--spec-type draft-mtp`) on a **checkpoint-based** target — any hybrid/recurrent arch not in `llm_arch_supports_rs_rollback` — aborts the server on the first partially-rejected draft:

```
E process: missing MTP boundary for seq_id=0 pos=42 (current=45/1 previous=44/1)
E srv  update_slots: failed to process speculative batch
Aborted
```

On rejection, the checkpoint-restore branch in `server-context.cpp` rewinds the KV/recurrent state and truncates the prompt, but never rewinds the speculative implementation's own bookkeeping — the MTP `pending_h` boundary stays at the failed verify positions while the replay batch restarts earlier, so the next `process()` fails and the server aborts. Rollback-capable targets (qwen3.5 family) never hit this path, and dense targets use partial `seq_rm`, which is why it went unnoticed.

## Fix

Snapshot the existing `common_speculative_get_state()` blob at the same point the speculative checkpoint is taken (boundary = n_past−1), restore it via `common_speculative_set_state()` in the checkpoint-restore rejection branch, clear it alongside `spec_ckpt`. The get/set-state machinery already existed for the prompt cache; it was just never invoked on checkpoint restore. +18 lines, no arch-specific code.

## Verification

Tested on a BailingMoeV3 (Ling-3.0-flash 124B/5.1B, KDA hybrid) target with `draft-mtp`: previously crashed on the first request with rejections; after the fix, sustained multi-request runs with the rejection path repeatedly exercised, zero `missing MTP boundary` errors, draft acceptance 90–95%, decode +22–36% vs no spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
