### PR TITLE
server: break speculative replay livelock on repeated checkpoint restore

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -75,6 +75,15 @@ struct server_slot {
     common_prompt_checkpoint spec_ckpt;
     bool spec_is_replay = false;
 
+    // livelock guard (issue #58): consecutive speculative checkpoint restores at the
+    // same position. When the context cannot apply partial draft acceptance the draft
+    // is truncated and the checkpoint replayed; if the replay reproduces the same
+    // rejection, the slot spins forever without advancing pos_next.
+    llama_pos spec_replay_pos   = -1;
+    int       spec_replay_stall = 0;
+    // one-shot: suppress drafting for the next iteration so a plain decode can advance
+    bool      spec_skip_draft   = false;
+
     // speculative-impl state (e.g. MTP boundary hidden rows) snapshotted together with
     // spec_ckpt, so that a checkpoint restore can also rewind the draft bookkeeping
     std::vector<uint8_t> spec_state;
@@ -223,6 +232,10 @@ struct server_slot {
         SLT_DBG(*this, "%s", "\n");
 
         spec_is_replay = false;
+
+        spec_replay_pos   = -1;
+        spec_replay_stall = 0;
+        spec_skip_draft   = false;
 
         n_prompt_tokens_cache = 0;
 
@@ -2441,6 +2454,15 @@ private:
 
                 int n_draft_max = slot.get_n_draft_max();
 
+                // livelock guard (issue #58), second half: skip drafting for exactly
+                // one iteration after a stalled replay. Combined with the cleared
+                // spec_draft this makes update_batch() take the plain decode path,
+                // which advances pos_next and breaks the loop.
+                if (slot.spec_skip_draft) {
+                    slot.spec_skip_draft = false;
+                    n_draft_max = 0;
+                }
+
                 if (strict_qwen_mtp_verification) {
                     // Dense-attention KV width is padded in 256-cell blocks.
                     // A verification batch that straddles a block makes its
@@ -3471,6 +3493,14 @@ private:
 
                             SLT_DBG(slot, "restoring speculative checkpoint (pos_min = %d, pos_max = %d, size = %zu)\n", ckpt.pos_min, ckpt.pos_max, ckpt.size());
 
+                            // track repeated restores at the same position (see #58)
+                            if (slot.spec_replay_pos == ckpt.pos_max) {
+                                slot.spec_replay_stall++;
+                            } else {
+                                slot.spec_replay_pos   = ckpt.pos_max;
+                                slot.spec_replay_stall = 1;
+                            }
+
                             {
                                 const bool restored_tgt = ckpt.load_tgt(slot.ctx_tgt, slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY | LLAMA_STATE_SEQ_FLAGS_ON_DEVICE);
                                 if (!restored_tgt) {
@@ -3506,6 +3536,25 @@ private:
                             // the restored KV; the replayed batch re-runs process() from here
                             if (!slot.spec_state.empty()) {
                                 common_speculative_set_state(spec.get(), slot.id, slot.spec_state);
+                            }
+
+                            // livelock guard (issue #58): this checkpoint position has
+                            // already been restored without the slot advancing, so
+                            // replaying the same draft would reproduce the same partial
+                            // rejection indefinitely. Drop the draft; with spec_draft
+                            // empty the next iteration decodes a single token without
+                            // speculation, which always makes forward progress. A plain
+                            // decode is exactly what runs with --spec-type none, so this
+                            // cannot change the generated output.
+                            if (slot.spec_replay_stall >= 2) {
+                                SLT_WRN(slot, "speculative replay stalled at pos %d (%d consecutive checkpoint restores) - dropping draft, decoding without speculation\n",
+                                        slot.spec_replay_pos, slot.spec_replay_stall);
+                                slot.spec_draft.clear();
+                                slot.spec_i_batch.clear();
+                                slot.spec_is_replay    = false;
+                                slot.spec_replay_stall = 0;
+                                slot.spec_replay_pos   = -1;
+                                slot.spec_skip_draft   = true;
                             }
 
                             continue;


### PR DESCRIPTION
Fixes #58.

## What happens

When the target context cannot apply partial draft acceptance (`COMMON_CONTEXT_SEQ_RM_TYPE_FULL`), a partially-accepted draft truncates the draft and restores the speculative checkpoint. If the replay reproduces the same partial rejection, the slot restores the *same* checkpoint position forever without advancing `pos_next`. The request never completes and is only terminated by client disconnect — `/health` stays `ok` throughout, so monitoring does not catch it.

Measured on a wedged request (`draft-dflash`, Qwen3.6-35B-A3B, Vulkan):

| | count |
|---|---|
| `generate_draft` calls | 5441 |
| `restoring speculative checkpoint` | 5362 |
| tokens actually emitted | 322 |

Every iteration was identical: `generate_draft: id=256, #tokens=101, #draft=2, pos_next=101` with `restoring speculative checkpoint (pos_min = 100, pos_max = 100)`.

Despite the issue title, the `spec-boundary-mismatch` prompt-cache miss is not the cause — it is a real but separate performance issue, and generation proceeds normally for ~80 tokens after it before the livelock begins. This reproduces on main both before and after #56, so it is not related to that change.

## Reproduction

Deterministic — wedges on request 3, every time:

```
llama-server -m Qwen3.6-35B-A3B-MTP-Q4_K_M.gguf -dev Vulkan0 -ngl 999 -np 1 -c 4096 --jinja \
  --spec-type draft-dflash -md aeon-dflash-drafter-q8_0.gguf \
  --spec-draft-device Vulkan0 --spec-draft-ngl all --spec-draft-n-max 4 --spec-draft-n-min 0
```

Then POST the same chat request repeatedly with `"max_tokens": 120` and content `"Explain how a four-stroke internal combustion engine works."` (141 prompt tokens). A shorter 119-token prompt does **not** reproduce it — the longer one reaches a state where a draft is *partially* accepted.

## The fix

Track consecutive checkpoint restores at the same position. On the second one, drop the draft and suppress drafting for a single iteration so `update_batch()` takes the plain decode path, which unconditionally advances `pos_next`.

Both halves are required: `update_batch()` branches on `spec_draft.empty()`, while draft generation is gated by `n_draft_max > 0`. Patching either alone still livelocks (verified both ways).

## Why it is safe

- A plain decode is exactly what runs with `--spec-type none`, so generated output is unchanged.
- The guard is unreachable in healthy operation: normal partial acceptance restores at *advancing* positions, which resets the counter.
- `n_draft_max = 0` is an existing pattern in this function (the `strict_qwen_mtp_verification` path uses it).
- It does not touch the strict `spec-boundary` cache check, so there is no risk of reusing a checkpoint whose speculative state does not line up.

## Testing

On this branch, off main:

- The repro above: **8/8 requests complete**, previously died at request 3 every time. The guard fires **once**.
- Throughput unchanged: 86.9 / 76.0 / 73.2 / 81.3 / 76.3 / 79.0 / 80.2 / 77.5 t/s (vs 86 / 75 for the two requests that used to succeed).
- `test-llama-archs`: 731 OK / 0 FAIL.

Only tested with `draft-dflash` on Vulkan/gfx1151. Worth confirming against the original reporter's ROCm/NixOS configuration before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
