### PR TITLE
ggml-alloc: fix uninitialized view tensors in the trailing buffer chunk

### DIFF
--- a/ggml/src/ggml-alloc.c
+++ b/ggml/src/ggml-alloc.c
@@ -1183,7 +1183,7 @@ static ggml_backend_buffer_t ggml_backend_alloc_ctx_tensors_from_buft_impl(
             this_size = GGML_PAD(ggml_backend_buft_get_alloc_size(buft, t), alignment);
         }
 
-        if (cur_buf_size > 0 && (cur_buf_size + this_size) > max_size) {
+        if (cur_buf_size > 0 && this_size > 0 && (cur_buf_size + this_size) > max_size) {
             // allocate tensors in the current buffer
             if (!no_alloc && !alloc_tensor_range(ctx, first, t, buft, cur_buf_size, &buffers, &n_buffers)) {
                 return NULL;


### PR DESCRIPTION
When iterating tensors for buffer splitting, the split condition could fire on a view tensor (this_size == 0) because the accumulated cur_buf_size alone exceeded max_size. This reset cur_buf_size to 0, so the trailing 'if (cur_buf_size > 0)' block was skipped and the last layer's view tensors (e.g. the k_stream views of the final attention layer in a KV cache) were never initialized (data == NULL, buffer == NULL).

Only split when the current tensor has a nonzero size; views must not trigger a new buffer. Verified on BAILINGMoe3 Ling-3.0-flash (Vulkan) where the last cache_k view caused 'ggml_backend_tensor_get' to assert tensor->data != NULL during prompt-cache save.

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
