### PR TITLE
convert: add LFM2.5 tokenizer chkhsh mappings

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1555,6 +1555,18 @@ class TextModel(ModelBase):
         if chkhsh == "169bf0296a13c4d9b7672313f749eb36501d931022de052aad6e36f2bf34dd51":
             # ref: https://huggingface.co/LiquidAI/LFM2-Tokenizer
             res = "lfm2"
+        if chkhsh == "1695bc99c38f06ed8a7ab6d3e066ff571f9c5f8759e6eeba60afd0f221e2e858":
+            # ref: https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct
+            res = "lfm2"
+        if chkhsh == "9e454714343b69b99b71795c1d27a68c2a1d15dab111f4d353109f966af29da7":
+            # ref: https://huggingface.co/LiquidAI/LFM2.5-8B-A1B
+            res = "lfm2"
+        if chkhsh == "5d5192db33764da7bf8147f23ca2c0f4e74fb549a2ecb9dc39eff533a5a267cc":
+            # ref: https://huggingface.co/LiquidAI/LFM2.5-8B-A1B (current tokenizer rev)
+            res = "lfm2"
+        if chkhsh == "87ab4b1536216e11d7a9b700bf6f8266d2742f26f436e8b557385f39cc891750":
+            # ref: https://huggingface.co/reaperdoesntknow/LFM2.5-8B-A1B-Opus-Distil
+            res = "lfm2"
         if chkhsh == "2085e1638f6c377a0aa4ead21b27bb4cb941bf800df86ed391011769c1758dfb":
             # ref: https://huggingface.co/LGAI-EXAONE/EXAONE-4.0-32B
             res = "exaone4"


### PR DESCRIPTION
## What
Adds 4 new `chkhsh` → `"lfm2"` mappings in `convert_hf_to_gguf.py` `get_vocab_base_pre()` so LFM2.5-family models convert without tokenizer mismatch failures.

The upstream `LFM2Model` / `LFM2MoeModel` classes already exist; the missing piece was vocabulary recognition for the **current** LFM2.5 tokenizer revisions.

## Hashes added
| chkhsh | model |
|--------|-------|
| `1695bc99c38f06ed8a7ab6d3e066ff571f9c5f8759e6eeba60afd0f221e2e858` | LFM2.5-1.2B-Instruct (current rev) |
| `9e454714343b69b99b71795c1d27a68c2a1d15dab111f4d353109f966af29da7` | LFM2.5-8B-A1B (upstream-recorded rev) |
| `5d5192db33764da7bf8147f23ca2c0f4e74fb549a2ecb9dc39eff533a5a267cc` | LFM2.5-8B-A1B / 2.6B / Fabliq (current rev) |
| `87ab4b1536216e11d7a9b700bf6f8266d2742f26f436e8b557385f39cc891750` | LFM2.5-8B-A1B-Opus-Distil |

## Why
LiquidAI's current `tokenizer.json` files hash differently than the single upstream-recorded LFM2.5 hash. All are the LFM2 pre-tokenizer class (verified: `tokenizer.ggml.pre=lfm2` in LiquidAI's own GGUFs; GGUF tokenize == HF tokenize on the chkhsh probe, 211/211 ids match for 1.2B).

Also appends the AI change-log entries (Sessions 004–007) per the repo's `AI_CHANGES.md` policy.

## Tested
- End-to-end requant of LFM2.5 1.2B / 2.6B / 8B-A1B / 8B-A1B-Opus-Distil / Fabliq-8B-Agent-FromBase to ROCmFPX types on the ROCmFPX fork.
- Tokenizer round-trip: 211/211 ids match HF tokenize on the probe text.