### PR TITLE
Revert M-RoPE n_past change: segfaults llama-server with --spec-mtp-strict-qwen

### DIFF
--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2517,18 +2517,7 @@ private:
                         common_speculative_get_draft_params(spec.get(), slot.id) = {
                             /* .drafting = */ true,
                             /* .n_max    = */ std::min(n_draft_max, sd.n_max),
-                            // NOTE: every consumer of this field treats it as a *position*
-                            // (batch positions, llama_memory_seq_rm bounds, and the MTP
-                            // boundary compare `pos_needed = n_past - 1`), not as a KV token
-                            // count. Those are the same number for text-only prompts, but
-                            // diverge under M-RoPE: an image chunk occupies n_tokens KV slots
-                            // while advancing position by only n_pos. Feeding the token count
-                            // here left the MTP boundary permanently offset by
-                            // (n_tokens - n_pos) after any image, so draft() disabled itself
-                            // for the rest of the sequence. pos_next() returns the same value
-                            // as n_tokens() when there is no media, so this is a no-op for
-                            // text-only models.
-                            /* .n_past   = */ slot.prompt.tokens.pos_next(),
+                            /* .n_past   = */ slot.prompt.n_tokens(),
                             /* .id_last  = */ slot.sampled,
                             /* .prompt   = */ &slot.spec_prompt,
                             /* .result   = */ &slot.spec_draft,


### PR DESCRIPTION
Reverts `61b71b5a2` — it segfaults `llama-server` on the first
`/v1/chat/completions` request when `--spec-mtp-strict-qwen` is active.

## Evidence

| build | first chat request |
|---|---|
| pre-merge `b2f5829db` | alive, 845 / 846 bytes ✅ |
| current `main` `82357de7f` | **SEGFAULT ×2** ❌ |
| `main` minus `61b71b5a2` | alive, 844 / 843 bytes ✅ |

Reproduced twice per build on gfx1151 / Vulkan with Qwen3.8-27B
ROCmFP4-STRIX_LEAN, `--spec-type draft-mtp --spec-draft-n-max 4
--spec-draft-p-min 0.0 --spec-mtp-strict-qwen`, GPU verified idle.

## Root cause

`common_speculative_draft_params::n_past` is consumed two ways: as an M-RoPE
**position** (batch positions, the MTP boundary compare `pos_needed = n_past-1`)
and as a KV **slot count** (`llama_memory_seq_rm` bounds, buffer indexing).
They are equal for text-only prompts, so feeding it `pos_next()` looked safe —
but the strict-qwen verification path indexes with the value and walks off the
buffer.

The original regression sweep (11 architectures × Vulkan + HIP, byte-identical
generated text) missed it because it drove `llama-cli` without strict-qwen
verification, which never reaches the crashing path.

## The underlying bug is still real

After an image chunk, `draft()` disables MTP for the remainder of the sequence
because `pending_h_pos` (M-RoPE space) never equals `dp.n_past - 1`
(token-count space) — measured 13.7 vs 32.2 t/s on image-bearing prompts.
The correct fix carries the position in its own field alongside `n_past` so
KV-count consumers keep their semantics. Deliberately not attempted here.

## Not affected by this revert

`7b02624ee` (NVFP4 lm_head scale), `52906256a` (NVFP4 quantize target) and
`dfc439dc1` (vision + draft-mtp abort fix) touch disjoint files. Verified on the
reverted build: a published NVFP4 GGUF and a ModelOpt-converted one both load and
generate correctly, 0 load errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
