### PR TITLE
spec: restore MTP across image chunks via a scoped pos_next field

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1769,7 +1769,13 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
 
             last_n_drafted[seq_id] = 0;
 
-            const llama_pos pos_needed = dp.n_past - 1;
+            // Draft positions must be in the target's RoPE space. They coincide
+            // with n_past for text-only prompts; after an image chunk they do not,
+            // and using n_past left pos_needed permanently offset so drafting was
+            // disabled for the rest of the sequence.
+            const llama_pos p_next = dp.pos_next >= 0 ? dp.pos_next : dp.n_past;
+
+            const llama_pos pos_needed = p_next - 1;
             if (!pending_h_valid[seq_id] || pending_h_pos[seq_id] != pos_needed) {
                 LOG_WRN("%s: disabling MTP draft for seq_id=%d: boundary pos=%d/%d, needed=%d\n",
                         __func__, (int) seq_id, (int) pending_h_pos[seq_id],
@@ -1782,7 +1788,7 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
             drafting[seq_id] = 1;
             common_sampler_reset(smpls[seq_id].get());
 
-            common_speculative_batch_add_one_seq(batch, dp.id_last, dp.n_past, seq_id, true);
+            common_speculative_batch_add_one_seq(batch, dp.id_last, p_next, seq_id, true);
             std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd, pending_h[seq_id].data(), row_bytes);
 
             i_last[seq_id] = batch.n_tokens - 1;
@@ -1810,7 +1816,7 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
                 auto * mem_dft = llama_get_memory(ctx_dft);
                 for (llama_seq_id seq_id = 0; seq_id < (llama_seq_id) n_seq; ++seq_id) {
                     if (drafting[seq_id]) {
-                        llama_memory_seq_rm(mem_dft, seq_id, dparams[seq_id].n_past, -1);
+                        llama_memory_seq_rm(mem_dft, seq_id, dparams[seq_id].pos_next >= 0 ? dparams[seq_id].pos_next : dparams[seq_id].n_past, -1);
                     }
                 }
                 llama_set_nextn_layer_offset(ctx_dft, i);
@@ -1881,17 +1887,17 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
                     const int n_rows = (int) result.size() + 1; // id_last + tokens drafted so far
                     for (int t = 0; t < n_rows; ++t) {
                         const llama_token tok = (t == 0) ? dp.id_last : result[t - 1];
-                        common_speculative_batch_add_one_seq(batch, tok, dp.n_past + t, seq_id, t == n_rows - 1);
+                        common_speculative_batch_add_one_seq(batch, tok, (dp.pos_next >= 0 ? dp.pos_next : dp.n_past) + t, seq_id, t == n_rows - 1);
                         std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd,
                                     chain_h[seq_id].data() + (size_t) t * n_embd, row_bytes);
                     }
                 } else if (is_mem_shared) {
                     // note: with shared memory (e.g. Gemma4 assistants) we use the same position for all draft tokens
                     // ref: https://github.com/huggingface/transformers/blob/effde20942e3f82a1b97449f60b3a48c5ff96145/docs/source/en/model_doc/gemma4_assistant.md?plain=1#L36-L37
-                    common_speculative_batch_add_one_seq(batch, id, dp.n_past, seq_id, true);
+                    common_speculative_batch_add_one_seq(batch, id, dp.pos_next >= 0 ? dp.pos_next : dp.n_past, seq_id, true);
                     std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd, h_row, row_bytes);
                 } else {
-                    common_speculative_batch_add_one_seq(batch, id, dp.n_past + i + 1, seq_id, true);
+                    common_speculative_batch_add_one_seq(batch, id, (dp.pos_next >= 0 ? dp.pos_next : dp.n_past) + i + 1, seq_id, true);
                     std::memcpy(batch.embd + (size_t) (batch.n_tokens - 1) * n_embd, h_row, row_bytes);
                 }
 

--- a/common/speculative.h
+++ b/common/speculative.h
@@ -36,6 +36,15 @@ struct common_speculative_draft_params {
     int32_t n_max = -1;
 
     llama_pos   n_past;
+
+    // RoPE position that the target model would assign to id_last's successor.
+    // Equals n_past for text-only prompts, but they diverge under M-RoPE: an
+    // image chunk occupies n_tokens KV slots while advancing position by only
+    // n_pos. Only the draft-mtp implementation consumes this; -1 means "caller
+    // supplied no M-RoPE-aware position", and consumers fall back to n_past so
+    // behaviour is byte-identical to before for every other caller and impl.
+    llama_pos   pos_next = -1;
+
     llama_token id_last;
 
     // TODO: remove in the future by keeping track of the prompt from the _begin() call and the consecutive accept calls

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2534,6 +2534,10 @@ private:
                             /* .drafting = */ true,
                             /* .n_max    = */ std::min(n_draft_max, sd.n_max),
                             /* .n_past   = */ slot.prompt.n_tokens(),
+                            // M-RoPE-aware position for the draft-mtp boundary and
+                            // draft batch positions. Same value as n_tokens() when the
+                            // prompt has no media, so this is inert for text-only.
+                            /* .pos_next = */ slot.prompt.tokens.pos_next(),
                             /* .id_last  = */ slot.sampled,
                             /* .prompt   = */ &slot.spec_prompt,
                             /* .result   = */ &slot.spec_draft,


### PR DESCRIPTION
Restores MTP speculation across image chunks, using a separate position field
rather than redefining `n_past`.

## The bug

After an image chunk, `draft()` disabled MTP for the remainder of the sequence.
`pending_h_pos` is recorded from `batch_in.pos` (M-RoPE space); the boundary
compare used `dp.n_past - 1` (token-count space). Equal for text-only prompts,
but an image occupies `n_tokens` KV slots while advancing position by only
`n_pos`, so the compare never matched again — **13.7 vs 32.2 t/s** on
image-bearing prompts.

## Why not just change n_past

`61b71b5a2` did exactly that and was reverted in #71: it segfaulted
`llama-server` on the first `/v1/chat/completions` request under
`--spec-mtp-strict-qwen`. `n_past` is shared with the `draft_simple` and
`dflash` implementations and with the server's own bookkeeping, so redefining
it left the sequence state inconsistent; the fault surfaced later inside
`common_prompt_checkpoint::update_tgt()` while serializing that state.

## This version

- adds `common_speculative_draft_params::pos_next`, defaulting to `-1`
- consumed **only** inside `common_speculative_state_draft_mtp`, falling back to
  `n_past` when `-1` — every other caller and impl is byte-identical
- `draft_simple` (`speculative.cpp:319,390`) and `dflash` (`:1218`) untouched
- server populates it from `slot.prompt.tokens.pos_next()`, which returns exactly
  `n_tokens()` when the prompt has no media

## Verification (gfx1151, Qwen3.8-27B ROCmFP4-STRIX_LEAN)

| check | result |
|---|---|
| chat + `--spec-mtp-strict-qwen` (crashed twice pre-revert) | `19 × 23 = 437`, 36.87 t/s, alive |
| image + draft-mtp | **28.71 t/s**, OCR correct, **0** `disabling MTP draft` warnings |
| Vulkan, 11 architectures | 9/11 byte-identical generated text |
| HIP, 11 architectures | 9/11 byte-identical generated text |

Architectures covered: `qwen35`, `qwen35moe`, `gemma4`, `laguna`, `deepseek2`,
`deepseek4`, `lfm2moe`, `step35`, `dspark`, `dflash`, `dflash-draft`.

The 2 differing entries per backend are models that segfault identically on both
builds (`rc=139`, 19–35 byte crash stubs, never reaching generation). The set is
not stable across backends — `dflash-draft` differs on Vulkan but matches on HIP,
`step35` the reverse — marking them as timing-dependent crash artifacts rather
than behavioural change.

The `/v1/chat/completions` + `--spec-mtp-strict-qwen` case is the gate the
original attempt lacked: the earlier 11-arch sweep drove `llama-cli` without
strict-qwen and never reached the crashing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
