### PR TITLE
fix(examples): pass pos_next in speculative-simple — unbreaks the build on main

### DIFF
--- a/examples/speculative-simple/speculative-simple.cpp
+++ b/examples/speculative-simple/speculative-simple.cpp
@@ -183,6 +183,7 @@ int main(int argc, char ** argv) {
                 /* .drafting   = */ true,
                 /* .n_max      = */ -1,
                 /* .n_past     = */ n_past,
+                /* .pos_next   = */ n_past, // no M-RoPE media here: position == token count
                 /* .id_last    = */ id_last,
                 /* .prompt     = */ &prompt_tgt,
                 /* .result     = */ &draft, // output


### PR DESCRIPTION
`7d43016f4` (PR #72) added `common_speculative_draft_params::pos_next` between `n_past` and `id_last`. `speculative-simple.cpp` uses a **positional aggregate initializer**, so the new field shifted every later member and the assignment stopped compiling:

```
examples/speculative-simple/speculative-simple.cpp:189:13: error: no match for 'operator='
  (operand types are 'common_speculative_draft_params' ...)
```

That is a hard compile error on every platform — **19 CI jobs failing on main**, where the pre-merge commit `b2f5829db` was **30/30 green**.

It slipped through because PR #72 was only ever built against the `llama-server` and `llama-cli` targets, never the full tree.

**Fix:** pass `pos_next = n_past` in the example. It drives a text-only prompt with no media, so the two are equal there and behaviour is unchanged.

**Verified:** full `cmake --build build` with all targets including examples on gfx1151/Vulkan — builds clean, `llama-speculative-simple` links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)