### PR TITLE
fix(dflash): silence unused-parameter error in dspark_apply_rope_tail

### DIFF
--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -684,6 +684,9 @@ static ggml_tensor * dspark_apply_rope_tail(
         int             rope_type,
         float           freq_base,
         bool            inverse) {
+    GGML_UNUSED(n_head);
+    GGML_UNUSED(n_tokens);
+
     if (n_rot == n_embd_head) {
         return inverse
             ? ggml_rope_ext_back(ctx, x, inp_pos, nullptr, n_rot, rope_type, 0,


### PR DESCRIPTION
`dspark_apply_rope_tail()` declares `n_head` and `n_tokens` but never references them — the body uses only `n_rot`, `n_embd_head`, `rope_type`, `freq_base` and `inverse`. Under `-Werror=unused-parameter` (which `LLAMA_FATAL_WARNINGS=ON` enables, as the `ubuntu-cpu` CI job does) that is a hard error:

```
src/models/dflash.cpp:681:24: error: unused parameter 'n_head'   [-Werror=unused-parameter]
src/models/dflash.cpp:682:24: error: unused parameter 'n_tokens' [-Werror=unused-parameter]
```

**Pre-existing, not a regression.** The function is byte-identical in `b2f5829db` and originates in "DeepseekV4 MTP + DSpark (#25784)". It surfaced only because the full CI matrix had not run on the preceding commits — those runs were cache-warming jobs.

## Approach

Uses `GGML_UNUSED()`, matching the convention already in `src/models` (e.g. `deepseek32.cpp:167`).

Chosen deliberately over removing the parameters:
- `GGML_UNUSED` expands to a no-op cast → **generated code is unchanged**
- the signature is preserved → all four call sites (759, 821, 829, 842) untouched

Removing the params would have meant editing four call sites in live DSpark/DeepSeek-V4 attention code for no benefit.

## Verification

Full build of **every target** at `-Werror` (`-DLLAMA_FATAL_WARNINGS=ON`) on gfx1151/Vulkan — the exact condition the CI job failed under:

- **552 objects, 0 errors, 114 binaries**
- `src/models/dflash.cpp` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)