### PR TITLE
fix: only claim lm_head scales for NVFP4, and save them

### DIFF
--- a/src/llama-model-saver.cpp
+++ b/src/llama-model-saver.cpp
@@ -393,6 +393,13 @@ void llama_model_saver::add_tensors_from_model() {
     add_tensor(model->output_norm);
     add_tensor(model->output_norm_b);
     add_tensor(model->output);
+    // ModelOpt NVFP4 checkpoints quantize lm_head, so output carries a ".scale"
+    // and ".input_scale". The per-layer loop below walks llama_layer as a flat
+    // pointer array and therefore picks up every layer scale for free, but this
+    // top-level list is hand-written - omitting these two silently dropped the
+    // lm_head scales on save, changing the logits of any round-tripped model.
+    add_tensor(model->output_s);
+    add_tensor(model->output_in_s);
     add_tensor(model->output_b);
     add_tensor(model->output_norm_enc);
     add_tensor(model->cls);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1427,10 +1427,22 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
         // checkpoints quantize lm_head too (it is one of the 193 W4A16_NVFP4
         // tensors in the qwen3_5 family recipe), so those two tensors were left
         // over and load failed with "wrong number of tensors; expected N, got N-2".
-        if (!output_s && output) {
+        //
+        // Only ask for them when lm_head is itself a scale-carrying quant. The
+        // request must not be unconditional: callers that synthesize a model
+        // rather than read a file (llama_model_init_from_user, as used by
+        // test-llama-archs) materialize every tensor that is asked for, so an
+        // unconditional request invents a random lm_head scale for models that
+        // have none. That is not harmless - it multiplies the final logits by
+        // a small random scalar, which costs enough relative precision on the
+        // Vulkan and Meta backends to fail the NMSE check on gemma2/gemma3n.
+        // Add further types here if other quants grow lm_head scales.
+        const bool output_has_scales = output && output->type == GGML_TYPE_NVFP4;
+
+        if (!output_s && output_has_scales) {
             output_s = create_tensor(tn(LLM_TENSOR_OUTPUT, "scale"), {1}, TENSOR_NOT_REQUIRED);
         }
-        if (!output_in_s && output) {
+        if (!output_in_s && output_has_scales) {
             output_in_s = create_tensor(tn(LLM_TENSOR_OUTPUT, "input_scale"), {1}, TENSOR_NOT_REQUIRED);
         }
     }


### PR DESCRIPTION
Fixes the `test-llama-archs` regression introduced by 7b02624ee (the lm_head-scale commit that made ModelOpt NVFP4 checkpoints loadable).

### Two distinct failures, one root cause

`llama_model_init_from_user` — used by `test-llama-archs` — materializes **every** tensor that `create_tensor()` asks for. Requesting `output.scale` unconditionally therefore invents a random lm_head scale for models that have none:

| symptom | effect |
|---|---|
| NMSE | random scalar shrinks the final logits; Vulkan/Meta lose relative precision. gemma2 `7.26e-07 → 1.70e-01`, gemma3n `4.78e-06 → 8.03e-01` (CPU exact throughout) |
| Roundtrip | `add_tensors_from_model()` never wrote the two tensors, so save/reload dropped them and logits diverged (`maincoder`, `minimax-m3`) |

### Fix

1. **Gate the request** on lm_head actually being a scale-carrying quant (`GGML_TYPE_NVFP4`).
2. **Save the tensors.** The saver's per-layer loop walks `llama_layer` as a flat pointer array, so every *layer* scale roundtrips for free — but the top-level list is hand-written. Omitting these two silently dropped the lm_head scales when saving a real NVFP4 model, which was a live data-loss bug independent of the test.

### Verification

- `test-llama-archs` **exits 0**, 413/413 rows, zero failures — identical row count and device set to the pre-7b02624ee baseline (`dfc439dc1`), which was also 0 failures.
- Full **all-targets build with `-DLLAMA_FATAL_WARNINGS=ON`**: 0 errors, 0 warnings.
- Both NVFP4 GGUFs load with no errors and answer correctly:
  - ModelOpt export (`output.scale` + `output.input_scale` + 193 per-layer scales) — the gate must be *true* here or load fails on tensor count
  - published mixbits Q5K (no scales at all) — unaffected, `nullptr` as before