### PR TITLE
TEMP DO NOT MERGE: CI probe (saver-only, no gate)

### DIFF
--- a/src/llama-model-saver.cpp
+++ b/src/llama-model-saver.cpp
@@ -393,6 +393,13 @@ void llama_model_saver::add_tensors_from_model() {
     add_tensor(model->output_norm);
     add_tensor(model->output_norm_b);
     add_tensor(model->output);
+    // ModelOpt NVFP4 checkpoints quantize lm_head, so output carries a ".scale"
+    // and ".input_scale". The per-layer loop below walks llama_layer as a flat
+    // pointer array and therefore picks up every layer scale for free, but this
+    // top-level list is hand-written - omitting these two silently dropped the
+    // lm_head scales on save, changing the logits of any round-tripped model.
+    add_tensor(model->output_s);
+    add_tensor(model->output_in_s);
     add_tensor(model->output_b);
     add_tensor(model->output_norm_enc);
     add_tensor(model->cls);


### PR DESCRIPTION
Throwaway draft, will be closed. Applies only the saver half of #75 so ggml-ci gets past Debug and runs the **Release** config, which `main` never reaches (its Debug run fails first). Purpose: determine whether the `mpt` `-nan` roundtrip failure on `ggml-ci-x64-cpu-high-perf` is introduced by the NVFP4 gate or latent in main.