### PR TITLE
fix(test): centre fabricated scale tensors on 1, not 0

### DIFF
--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -38,10 +38,27 @@ static double nmse(const std::vector<float> & a, const std::vector<float> & b) {
     return mse_a_b / mse_a_0;
 }
 
+// Scale tensors are semantically multipliers/divisors, so they must be centred
+// on 1 rather than 0. Drawing them from N(0, 1e-2) like ordinary weights puts
+// them arbitrarily close to zero, and MPT divides by one of them
+// (ffn.act.scales, see llama-graph.cpp: ggml_div(cur, act_scales)). A near-zero
+// draw turned that division into inf, which propagated to NaN logits and failed
+// the roundtrip check, because NaN != NaN is always true. That made the test
+// flaky in a seed-dependent way: ~1 seed in 12 for mpt.
+static bool is_scale_tensor(const char * name) {
+    const std::string n = name;
+    const auto ends_with = [&n](const char * suffix) {
+        const std::string s = suffix;
+        return n.size() >= s.size() && n.compare(n.size() - s.size(), s.size(), s) == 0;
+    };
+    return ends_with(".scale") || ends_with(".scales") || ends_with(".input_scale");
+}
+
 static void set_tensor_data(struct ggml_tensor * tensor, void * userdata) {
     std::hash<std::string> hasher;
     std::mt19937 gen(hasher(tensor->name) + *(const size_t *) userdata);
-    std::normal_distribution<float> dis(0.0f, 1.0e-2f);
+    const float mean = is_scale_tensor(tensor->name) ? 1.0f : 0.0f;
+    std::normal_distribution<float> dis(mean, 1.0e-2f);
 
     const int64_t ne = ggml_nelements(tensor);
     if (tensor->type == GGML_TYPE_F32) {


### PR DESCRIPTION
Fixes the seed-dependent `test-llama-archs` failure that has been red on `ggml-ci-x64-cpu-high-perf`.

### Root cause

`set_tensor_data` fills every materialised tensor from `N(0, 1e-2)`. That is correct for weights, but scales are **multipliers and divisors** — and MPT divides by one:

```cpp
// models/mpt.cpp
layer.ffn_act = create_tensor(tn(LLM_TENSOR_FFN_ACT, "scales", i), {n_ff}, TENSOR_NOT_REQUIRED);

// llama-graph.cpp
if (act_scales != NULL) {
    cur = ggml_div(ctx0, cur, act_scales);
}
```

A near-zero draw makes that division produce `inf`, which propagates to NaN logits. The roundtrip check compares with `!=`, and **`NaN != NaN` is always true**, so it fails unconditionally. The NMSE column prints `OK (-nan)` for the same reason — `nan > 1e-4` is false.

Located with a temporary eval callback:

```
FIRST BAD NODE: ffn_act-0   op=DIV   nan=0 inf=128   ne=[384,64,1,1]
      src0: ffn_gelu-0
      src1: blk.0.ffn.act.scales
```

### Why it looked like a phantom

Seed-dependent, roughly **1 seed in 12** for `mpt`. Local runs kept passing on other seeds; CI drew `688580224` and failed. It is not machine-specific — with that seed it reproduces on this box, and it reproduces identically on `main` and on commits predating the lm_head work, so it is long-standing rather than newly introduced.

### Fix

Draw `*.scale`, `*.scales`, `*.input_scale` from `N(1, 1e-2)`. A scale of ~0 is not a meaningful value for any of them. Test-only change; no inference code touched.

### Verification

- `mpt` at CI's exact seed `688580224`: **FAIL → OK**
- seed sweep: **0/12 fail** (was 1/12)
- full suite: **0 failures across 276 rows** at three seeds (`688580224`, `424242`, `8675309`)