### PR TITLE
fix(completion): let the ROCm clang build compile with -Werror

### DIFF
--- a/tools/completion/completion.cpp
+++ b/tools/completion/completion.cpp
@@ -33,12 +33,16 @@
 #endif
 
 static llama_context           ** g_ctx;
-static llama_model             ** g_model;
+// Assigned but never read: the interrupt handler above only consumes g_ctx and
+// g_smpl. Kept (rather than deleted) to stay in step with upstream, which reads
+// these in its own handler. Marked so the ROCm clang build, which enables
+// -Wunused-but-set-global where gcc does not, still compiles with -Werror.
+static llama_model             ** g_model [[maybe_unused]];
 static common_sampler          ** g_smpl;
 static common_params            * g_params;
-static std::vector<llama_token> * g_input_tokens;
-static std::ostringstream       * g_output_ss;
-static std::vector<llama_token> * g_output_tokens;
+static std::vector<llama_token> * g_input_tokens [[maybe_unused]];
+static std::ostringstream       * g_output_ss [[maybe_unused]];
+static std::vector<llama_token> * g_output_tokens [[maybe_unused]];
 static bool is_interacting  = false;
 static bool need_insert_eot = false;
 


### PR DESCRIPTION
The fork currently **cannot be built with `-DLLAMA_FATAL_WARNINGS=ON` on ROCm**.

```
completion.cpp:36:35: error: variable 'g_model' set but not used [-Werror,-Wunused-but-set-global]
   ...also g_input_tokens, g_output_ss, g_output_tokens
```

`g_ctx` and `g_smpl` *are* read by the interrupt handler (`common_perf_print`); these four are assigned and never read — leftovers from an upstream handler that also dumped tokens. They arrived with `4e8f35aef`.

**Invisible to CI**: there is no AMD GPU runner, and gcc (the Vulkan build) doesn't emit `-Wunused-but-set-global`. Only the ROCm clang toolchain does.

Marked `[[maybe_unused]]` rather than deleted, to stay in step with upstream, which reads them in its own handler.

**Verified**: full HIP+Vulkan build, gfx1151 / ROCm 7.14, **all targets**, `-DLLAMA_FATAL_WARNINGS=ON` → 0 errors, 0 warnings. This was the only blocker.