### PR TITLE
server: per-request reasoning_budget_message and exact cache round-trip with a wrap-up message

### DIFF
--- a/tools/cli/cli.cpp
+++ b/tools/cli/cli.cpp
@@ -111,11 +111,14 @@ struct cli_context {
                 }
                 task.params.sampling.reasoning_budget_end =
                     common_tokenize(vocab, chat_params.thinking_end_tag, false, true);
-                // '\n' before the end tag: chat templates re-render an assistant turn as
-                // '<think>\n' + reasoning_content + '\n</think>\n\n', so without it a
+                // '\n' before the end tag (and after a non-empty wrap-up message): chat
+                // templates re-render an assistant turn as '<think>\n' +
+                // reasoning_content|trim + '\n</think>\n\n', so without it a
                 // budget-truncated turn does not round-trip on session resend
                 task.params.sampling.reasoning_budget_forced =
-                    common_tokenize(vocab, "\n" + defaults.sampling.reasoning_budget_message + chat_params.thinking_end_tag, false, true);
+                    common_tokenize(vocab, "\n" + defaults.sampling.reasoning_budget_message
+                        + (defaults.sampling.reasoning_budget_message.empty() ? "" : "\n")
+                        + chat_params.thinking_end_tag, false, true);
             }
 
             rd.post_task({std::move(task)});

--- a/tools/server/server-common.cpp
+++ b/tools/server/server-common.cpp
@@ -1189,7 +1189,10 @@ json oaicompat_chat_params_parse(
             llama_params["reasoning_budget_tokens"] = reasoning_budget;
             llama_params["reasoning_budget_start_tag"] = chat_params.thinking_start_tag;
             llama_params["reasoning_budget_end_tag"] = chat_params.thinking_end_tag;
-            llama_params["reasoning_budget_message"] = opt.reasoning_budget_message;
+            // the copy-through of remaining body keys below skips keys already set
+            // here, so the per-request message must be read explicitly (CLI default
+            // otherwise, as done for the budget itself)
+            llama_params["reasoning_budget_message"] = json_value(body, "reasoning_budget_message", opt.reasoning_budget_message);
         }
     }
 

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -506,10 +506,14 @@ task_params server_task::params_from_json_cmpl(
         if (!end_tag.empty()) {
             params.sampling.reasoning_budget_end = common_tokenize(vocab, end_tag, false, true);
             // il template re-renderizza un turno assistant passato come
-            // '<think>\n' + reasoning_content + '\n</think>\n\n': il '\n' prima dell'end tag
-            // deve far parte della sequenza forzata, altrimenti un turno tagliato dal budget
-            // non round-trippa nel resend del client e la prompt cache diverge alla chiusura
-            params.sampling.reasoning_budget_forced = common_tokenize(vocab, "\n" + message + end_tag, false, true);
+            // '<think>\n' + reasoning_content|trim + '\n</think>\n\n': la sequenza forzata
+            // deve portare un '\n' PRIMA dell'end tag e, quando c'e' un messaggio di
+            // chiusura, anche un '\n' DOPO il messaggio (il trim dell'estratto rimuove i
+            // whitespace di coda, quindi il resend ricompone esattamente '\n' + messaggio
+            // + '\n' + end_tag); senza di cio' un turno tagliato dal budget non round-trippa
+            // nel resend del client e la prompt cache diverge alla chiusura
+            params.sampling.reasoning_budget_forced = common_tokenize(
+                vocab, "\n" + message + (message.empty() ? "" : "\n") + end_tag, false, true);
 
             SRV_DBG("reasoning budget: tokens=%d, generation_prompt='%s', start=%zu toks, end=%zu toks, forced=%zu toks\n",
                 budget, params.sampling.generation_prompt.c_str(),


### PR DESCRIPTION
Follow-up to #69 — completes the reasoning-budget round-trip when a wrap-up message is configured. Two commits, both running in production since Aug 16 on Qwen3.8-27B (hybrid recurrent) + MTP n-6.

## 1. `reasoning_budget_message` per-request on the OAI chat path

The generic copy-through of remaining body keys in `oaicompat_chat_params_parse` (`for (const auto & item : body.items())`) skips keys already present in `llama_params`, so the CLI value pre-populating `reasoning_budget_message` silently shadowed any per-request one — the body field was ignored on `/v1/chat/completions` (it worked on `/completion`, which reads it directly). Read the body field explicitly with the CLI value as default, mirroring what the `thinking_token_budget` alias handling does for the budget count.

## 2. Separate newline between wrap-up message and end tag

Chat templates re-render a resent assistant turn as `'<think>\n' + reasoning_content|trim + '\n</think>\n\n'` (verified against the Qwen3.8 chat template extracted from the GGUF). The `|trim` strips the trailing newline from the extracted reasoning, so the forced tail `'\n' + message + end_tag` from #69 diverges at the message/end-tag boundary: the re-render adds a `'\n'` the generation never emitted, and the resend pays a checkpoint rollback instead of an exact hit.

Fix: emit `'\n' + message + '\n' + end_tag` when a wrap-up message is set; keep the bare `'\n' + end_tag` when empty — that is the exact-hit case already verified in #69 and it stays untouched.

## Verification (two scripted runs on the production image)

- **Run 1, wiring only (commit 1):** the per-request message reaches the forced tail and appears in the extracted reasoning; but a resent budget-truncated turn paid a checkpoint rollback (lcp=280 on cached=534; lcp=1338 on 1398) — divergence exactly at the message→end-tag boundary.
- **Run 2, both commits:** regression check with an empty message and wrap-up round-trip with the message set: **zero cold fallbacks, zero rollbacks — exact cache hit with the message in the forced tail**; multi-turn session with two truncations also clean.
- Production since Aug 16: 9/10 dense agent tasks hit `budget exhausted → forcing → forced complete` with the per-request message active, all clean (27/27 marker-matched runs).

## Note

Default remains no message (`--reasoning-budget-message`, default: none). An explicitly configured message should not carry trailing whitespace: the template `|trim` would strip it and the resend would pay a bounded rollback (covered by the checkpoint salvage from #69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)