### PR TITLE
convert: add missing laguna pre-tokenizer hash, stop losing the lfm2 ones

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -1510,6 +1510,21 @@ class TextModel(ModelBase):
         # NOTE: if you get an error here, you need to update the convert_hf_to_gguf_update.py script
         #       or pull the latest version of the model from Huggingface
         #       don't edit the hashes manually!
+        if chkhsh == "169bf0296a13c4d9b7672313f749eb36501d931022de052aad6e36f2bf34dd51":
+            # ref: https://huggingface.co/LiquidAI/LFM2-Tokenizer
+            res = "lfm2"
+        if chkhsh == "1695bc99c38f06ed8a7ab6d3e066ff571f9c5f8759e6eeba60afd0f221e2e858":
+            # ref: https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct
+            res = "lfm2"
+        if chkhsh == "9e454714343b69b99b71795c1d27a68c2a1d15dab111f4d353109f966af29da7":
+            # ref: https://huggingface.co/LiquidAI/LFM2.5-8B-A1B
+            res = "lfm2"
+        if chkhsh == "5d5192db33764da7bf8147f23ca2c0f4e74fb549a2ecb9dc39eff533a5a267cc":
+            # ref: https://huggingface.co/LiquidAI/LFM2.5-8B-A1B
+            res = "lfm2"
+        if chkhsh == "87ab4b1536216e11d7a9b700bf6f8266d2742f26f436e8b557385f39cc891750":
+            # ref: https://huggingface.co/reaperdoesntknow/LFM2.5-8B-A1B-Opus-Distil
+            res = "lfm2"
         if chkhsh == "b6e8e1518dc4305be2fe39c313ed643381c4da5db34a98f6a04c093f8afbe99b":
             # ref: https://huggingface.co/THUDM/glm-4-9b-chat
             res = "chatglm-bpe"
@@ -1714,21 +1729,6 @@ class TextModel(ModelBase):
         if chkhsh == "f6791d196f87ce6b56a7d234be618e0d58f8cda3549416635b2bebcd22cd95c4":
             # ref: https://huggingface.co/K-intelligence/Midm-2.0-Base-Instruct
             res = "midm-2.0"
-        if chkhsh == "169bf0296a13c4d9b7672313f749eb36501d931022de052aad6e36f2bf34dd51":
-            # ref: https://huggingface.co/LiquidAI/LFM2-Tokenizer
-            res = "lfm2"
-        if chkhsh == "1695bc99c38f06ed8a7ab6d3e066ff571f9c5f8759e6eeba60afd0f221e2e858":
-            # ref: https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct
-            res = "lfm2"
-        if chkhsh == "9e454714343b69b99b71795c1d27a68c2a1d15dab111f4d353109f966af29da7":
-            # ref: https://huggingface.co/LiquidAI/LFM2.5-8B-A1B
-            res = "lfm2"
-        if chkhsh == "5d5192db33764da7bf8147f23ca2c0f4e74fb549a2ecb9dc39eff533a5a267cc":
-            # ref: https://huggingface.co/LiquidAI/LFM2.5-8B-A1B (current tokenizer rev)
-            res = "lfm2"
-        if chkhsh == "87ab4b1536216e11d7a9b700bf6f8266d2742f26f436e8b557385f39cc891750":
-            # ref: https://huggingface.co/reaperdoesntknow/LFM2.5-8B-A1B-Opus-Distil
-            res = "lfm2"
         if chkhsh == "2085e1638f6c377a0aa4ead21b27bb4cb941bf800df86ed391011769c1758dfb":
             # ref: https://huggingface.co/LGAI-EXAONE/EXAONE-4.0-32B
             res = "exaone4"
@@ -1777,6 +1777,9 @@ class TextModel(ModelBase):
         if chkhsh == "62f6fb0a6fd5098caeabb19b07a5c1099cafc8b9c40eab6ea89ece4ec02fbc57":
             # ref: https://huggingface.co/sarvamai/sarvam-30b
             res = "sarvam-moe"
+        if chkhsh == "972da7b59cec44d1f0a490a86c96df53859e486e481563e5dddac155013d87ac":
+            # ref: https://huggingface.co/poolside/Laguna-XS.2
+            res = "laguna"
 
         if res is None:
             logger.warning("\n")

--- a/convert_hf_to_gguf_update.py
+++ b/convert_hf_to_gguf_update.py
@@ -139,7 +139,6 @@ models = [
     {"name": "seed-coder",       "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/ByteDance-Seed/Seed-Coder-8B-Base", },
     {"name": "a.x-4.0",          "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/skt/A.X-4.0", },
     {"name": "midm-2.0",         "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/K-intelligence/Midm-2.0-Base-Instruct", },
-    {"name": "lfm2",             "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/LiquidAI/LFM2-Tokenizer"},
     {"name": "exaone4",          "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/LGAI-EXAONE/EXAONE-4.0-32B", },
     {"name": "mellum",           "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/JetBrains/Mellum-4b-base", },
     {"name": "modern-bert",      "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/answerdotai/ModernBERT-base", },
@@ -161,6 +160,15 @@ models = [
 
 # some models are known to be broken upstream, so we will skip them as exceptions
 pre_computed_hashes = [
+    # lfm2 ships several tokenizer revisions/forks that all map to the same
+    # pre-tokenizer. They must be pre-computed: get_existing_models() keys by
+    # res name, so a single models-list entry can only ever round-trip one of
+    # them and regeneration would silently drop the rest.
+    {"name": "lfm2", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/LiquidAI/LFM2-Tokenizer", "chkhsh": "169bf0296a13c4d9b7672313f749eb36501d931022de052aad6e36f2bf34dd51"},
+    {"name": "lfm2", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct", "chkhsh": "1695bc99c38f06ed8a7ab6d3e066ff571f9c5f8759e6eeba60afd0f221e2e858"},
+    {"name": "lfm2", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B", "chkhsh": "9e454714343b69b99b71795c1d27a68c2a1d15dab111f4d353109f966af29da7"},
+    {"name": "lfm2", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/LiquidAI/LFM2.5-8B-A1B", "chkhsh": "5d5192db33764da7bf8147f23ca2c0f4e74fb549a2ecb9dc39eff533a5a267cc"},
+    {"name": "lfm2", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/reaperdoesntknow/LFM2.5-8B-A1B-Opus-Distil", "chkhsh": "87ab4b1536216e11d7a9b700bf6f8266d2742f26f436e8b557385f39cc891750"},
     # chatglm-bpe has 2 hashes, why?
     {"name": "chatglm-bpe", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/THUDM/glm-4-9b-chat", "chkhsh": "b6e8e1518dc4305be2fe39c313ed643381c4da5db34a98f6a04c093f8afbe99b"},
     {"name": "chatglm-bpe", "tokt": TOKENIZER_TYPE.BPE, "repo": "https://huggingface.co/THUDM/glm-4-9b-chat", "chkhsh": "81d72c7348a9f0ebe86f23298d37debe0a5e71149e29bd283904c02262b27516"},


### PR DESCRIPTION
`Check Pre-Tokenizer Hashes` fails on **every** PR touching `convert_hf_to_gguf.py`. It only triggers on changes to that file, so it sat unnoticed until #79 came along.

### Fault 1 — laguna has no hash

`62ba5fb30` ("llama: port Laguna model support") added the tokenizer to the models list but never regenerated `convert_hf_to_gguf.py`. `--check-missing` skips downloading by design, so it tries to compute the hash, finds nothing locally, and raises:

```
OSError: Config for tokenizer laguna not found. The model may not exist
         or is not accessible with the provided token.
```

The message is misleading — `poolside/Laguna-XS.2` is public and reachable. It's a **missing hash**, not an access problem.

laguna is also the *only* genuinely missing entry. The other five names absent from the converter (`llama-spm`, `phi-3`, `gemma`, `gemma-2`, `t5`) are SPM/UGM, which the generator skips outright since `get_vocab_base_pre()` only covers BPE.

### Fault 2 — following the workflow's advice would delete four lfm2 hashes

The failure message says to run the update script and commit the result. Doing that **silently drops four `lfm2` hashes**:

```
- 169bf029...  LFM2-Tokenizer
- 1695bc99...  LFM2.5-1.2B-Instruct
- 9e454714...  LFM2.5-8B-A1B
- 5d5192db...  LFM2.5-8B-A1B (current rev)
```

`get_existing_models()` keys by `res` name, so one models-list entry can only round-trip **one** hash per name. Those four had been hand-added and were structurally unreproducible; the fifth also had its ref comment rewritten to the wrong repo.

All five now live in `pre_computed_hashes` — the mechanism already used for exactly this in `chatglm-bpe` (2 hashes), `glm4` (3) and `falcon-h1` (4) — and the redundant models-list entry is dropped.

### Verification

Run with the workflow's own steps, from a clean tree with no `models/tokenizers/` (as CI does):

- `convert_hf_to_gguf_update.py --check-missing` → **exit 0** (was 1)
- committed file matches generated → **diff step passes**
- hash count **87 → 88**: laguna added, **zero lost**, lfm2 still has 5 entries

The only content change is relocating the five lfm2 blocks to where the generator emits pre-computed hashes. One ref comment loses its `(current tokenizer rev)` annotation, since refs are derived from the entry's repo URL.