### PR TITLE
ggml-hip: drop -ffast-math, matching upstream

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -167,4 +167,9 @@ endif()
 
 target_link_libraries(ggml-hip PRIVATE ggml-base hip::host roc::rocblas roc::hipblas)
 
-target_compile_options(ggml-hip PRIVATE "$<$<COMPILE_LANGUAGE:HIP>:-ffast-math>")
+# NOTE: do not add -ffast-math / -funsafe-math-optimizations here. Upstream
+# tried both and removed them (ggml-org/llama.cpp#25495, #26696): they imply
+# -fassociative-math, which reassociates FP reductions and can flip greedy
+# argmax on RDNA3.5, making MTP speculative decode diverge from the
+# non-speculative baseline. gfx1151 is RDNA3.5, and -ffinite-math-only also
+# breaks inf handling outright (EXPM1 returned NaN where the CPU returns inf).


### PR DESCRIPTION
The HIP build has carried `-ffast-math` since the initial source snapshot (`4e8f35aef`, June). Upstream added the same flag *later*, then removed it **twice**:

- [ggml-org/llama.cpp#25495](https://github.com/ggml-org/llama.cpp/pull/25495) — Disable `-ffast-math` on HIP
- [ggml-org/llama.cpp#26696](https://github.com/ggml-org/llama.cpp/pull/26696) — remove `-funsafe-math-optimizations`

Their reasoning describes this fork's hardware and its headline feature exactly:

> It enables `-fassociative-math`, which reassociates FP reductions and can **flip greedy argmax on RDNA3.5** (e.g. **MTP speculative decode diverging from the non-speculative baseline**). Drop it so HIP builds are IEEE-conformant.

**gfx1151 is RDNA3.5**, and MTP speculative decode is what this fork exists for.

### Measured on gfx1151 / ROCm 7.14 (HIP build, otherwise identical)

| | with `-ffast-math` | without |
|---|---|---|
| `test-backend-ops` failures | **60** | **14** |
| `EXPM1` NaN (`ROCm0=-nan` vs `CPU=inf`) | 2 | **0** |
| `MUL_MAT_ID` failures | 45 | **8** |
| `ROPE_SET_ROWS(q3_0_rocmfpx)` ERR | 7.466e-6 | 3.120e-6 |

`-ffinite-math-only` lets the compiler assume inf/NaN cannot occur, so `EXPM1` returned NaN where the CPU returns inf.

The pre-existing `MUL_MAT_ID f16 ERR≈1.0` defect is **not** fixed here — but the flag was inflating it from 8 failing cases to 45, so a large share of what looked like a kernel bug was this compiler flag.

### Cost: ~2% decode

Three alternating runs, Qwen3.8-27B ROCmFP4-STRIX_LEAN, `-ngl 99`, greedy:

```
with     14.1, 14.4, 14.4 t/s   (mean 14.3)
without  13.7, 14.1, 14.2 t/s   (mean 14.0)   <- 13.7 was a cold first run
```

`test-llama-archs` on the resulting build: **exit 0, 413 rows, 0 failures**. Output stays coherent, arithmetic stays correct.

Two percent is a poor trade for a build that can emit NaN where the reference emits inf, and that upstream found can flip argmax mid-speculation on this exact architecture.