### PR TITLE
TEMP DO NOT MERGE: CI control probe for #82

### DIFF
--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -168,3 +168,5 @@ endif()
 target_link_libraries(ggml-hip PRIVATE ggml-base hip::host roc::rocblas roc::hipblas)
 
 target_compile_options(ggml-hip PRIVATE "$<$<COMPILE_LANGUAGE:HIP>:-ffast-math>")
+
+# CI control: no-op comment to trigger the same workflows as PR #82.


### PR DESCRIPTION
Comment-only change to `ggml/src/ggml-hip/CMakeLists.txt`, to fire the same workflows as #82. Purpose: determine whether the `windows-latest (openblas-x64)` **Test** failure on #82 is pre-existing on main or caused by removing `-ffast-math`. Will be closed and the branch deleted.