### PR TITLE
Fix Nemotron-H MoE: load NVFP4 expert scale2 tensors + remove double-scale

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1962,14 +1962,8 @@ ggml_tensor * llm_graph_context::build_moe_ffn(
         cb(experts, "ffn_moe_down_biased", il);
     }
 
-    // apply per-expert scale2 to down
-    if (down_exps_s) {
-        ggml_tensor * s = ggml_reshape_3d(ctx0, down_exps_s, 1, n_expert, 1);
-        s = ggml_repeat_4d(ctx0, s, 1, n_expert, n_tokens, 1);
-        s = ggml_get_rows(ctx0, s, selected_experts); // [1, n_expert_used, n_tokens]
-        experts = ggml_mul(ctx0, experts, s);
-        cb(experts, "ffn_moe_down_scaled", il);
-    }
+    // Note: per-expert scale2 is already applied inside build_lora_mm_id
+    // (the explicit block here was double-applying it)
 
     if (!weight_before_ffn && !weight_before_down) {
         experts = ggml_mul(ctx0, experts, weights);

--- a/src/models/nemotron-h.cpp
+++ b/src/models/nemotron-h.cpp
@@ -102,9 +102,17 @@ void llama_model_nemotron_h::load_arch_tensors(llama_model_loader &) {
                 layer.ffn_down_exps   = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), {n_ff_exp,   moe_n_embd, n_expert}, 0);
                 layer.ffn_up_exps     = create_tensor(tn(LLM_TENSOR_FFN_UP_EXPS,   "weight", i), {moe_n_embd, n_ff_exp, n_expert}, 0);
 
+                // NVFP4 per-tensor scale2 for routed experts
+                layer.ffn_up_exps_s   = create_tensor(tn(LLM_TENSOR_FFN_UP_EXPS,   "scale", i), {n_expert}, TENSOR_NOT_REQUIRED);
+                layer.ffn_down_exps_s = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "scale", i), {n_expert}, TENSOR_NOT_REQUIRED);
+
                 // Shared expert branch
                 layer.ffn_down_shexp  = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP, "weight", i), {n_ff_shexp, n_embd}, 0);
                 layer.ffn_up_shexp    = create_tensor(tn(LLM_TENSOR_FFN_UP_SHEXP,   "weight", i), {n_embd, n_ff_shexp}, 0);
+
+                // NVFP4 per-tensor scale2 for shared expert
+                layer.ffn_up_shexp_s   = create_tensor(tn(LLM_TENSOR_FFN_UP_SHEXP,   "scale", i), {1}, TENSOR_NOT_REQUIRED);
+                layer.ffn_down_shexp_s = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP, "scale", i), {1}, TENSOR_NOT_REQUIRED);
 
             } else {
                 // mlp layers


### PR DESCRIPTION
Fixes #85

## Problem

NVFP4 models on Nemotron-H MoE produce repetitive garbage output. Root cause: expert per-tensor scale2 tensors are never loaded, and down-projection scale2 is applied twice.

## Changes

### 1. `src/models/nemotron-h.cpp` — load expert scale2 tensors

`load_arch_tensors()` creates expert weight tensors but never creates the scale2 tensors. The graph code already passes them to `build_moe_ffn()` / `build_ffn()`, but they are NULL.

Add 4 `create_tensor` calls (all `TENSOR_NOT_REQUIRED`):
- `ffn_up_exps_s` / `ffn_down_exps_s` — shape `{n_expert}` (per-expert scalar)
- `ffn_up_shexp_s` / `ffn_down_shexp_s` — shape `{1}` (shared expert scalar)

### 2. `src/llama-graph.cpp` — remove double-scale application

`build_lora_mm_id()` already applies `w_s` via `ggml_mul` internally. But `build_moe_ffn()` also had an explicit block applying `down_exps_s` again — scale2 applied **twice** (squared). Remove the explicit block.

## Verification

Tested on gfx1151 (Strix Halo) and gfx1201 (R9700) with NVIDIA Nemotron-3.5-Lightning-30B-A3B-NVFP4:

```
Prompt: "The capital of France is"
Output: " Paris.  The capital of Germany is Berlin"
```

Needle-in-haystack (256K context):

| Context | Needle | Entropy | Top-1 |
|---------|--------|---------|-------|
| 4K      | YES    | 0.12    | 0.97  |
| 64K     | YES    | 0.17    | 0.95  |
| 128K    | YES    | 0.22    | 0.93  |

Needle found at 4K-128K with stable entropy. 19.8GB model, -ngl 999 -c 262144, all on GPU.

## Converter fixes also needed (documented in #85, not in this PR)

1. `convert_hf_to_gguf.py` line ~955: `quant_algo == "NVFP4"` should be substring match (ModelOpt uses `"W4A16_NVFP4"`)
2. `convert_hf_to_gguf.py` line ~690: `dequant_simple` called on NVFP4 uint8 weights — skip non-FP8 weights so `_generate_nvfp4_tensors()` handles them