### PR TITLE
llm_graph_result::reset(): also reset t_h_pre_norm

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1002,6 +1002,7 @@ void llm_graph_result::reset() {
     t_logits      = nullptr;
     t_embd        = nullptr;
     t_embd_pooled = nullptr;
+    t_h_pre_norm  = nullptr;
 
     t_layer_inp.resize(LLAMA_MAX_LAYERS + 1);
     std::fill(t_layer_inp.begin(), t_layer_inp.end(), nullptr);


### PR DESCRIPTION
## Overview

reset() clears every result tensor pointer (t_logits, t_embd, t_embd_pooled, …) except t_h_pre_norm, which keeps the previous graph's pointer. When a later graph doesn't produce a pre-norm output — not all model graph paths set it — the stale pointer aliases an unrelated tensor in the rebuilt compute arena.

Symptoms: with embeddings_pre_norm enabled, the extraction in llama_context::decode() either hard-asserts (ggml_backend_sched_get_tensor_backend returns null — we caught it pointing at attn_inp_kq_mask) or, worse, silently reads the wrong tensor into the pre-norm buffer.

Repro: any target+draft setup where the draft context enables pre-norm extraction but only some batch types set t_h_pre_norm (we hit it with a draft-dflash decoder on gfx1100/HIP; first decode after prefill asserts at llama-context.cpp:2076). This may also be implicated in the DFlash weirdness reported in #44.

One-line fix; no behavior change for graphs that do set the tensor.



- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Claude Fable 5 found and implemented this.
