### PR TITLE
hip: tune RDNA3.5 MMQ workgroup geometry

### DIFF
--- a/ggml/src/ggml-cuda/mmq.cuh
+++ b/ggml/src/ggml-cuda/mmq.cuh
@@ -146,7 +146,13 @@ static constexpr __device__ int get_mmq_x_max_device() {
 #endif // defined(AMD_MFMA_AVAILABLE) || defined(TURING_MMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
 }
 
+// Keep the RDNA3.5 tile height in sync with mmq_get_nwarps_* below:
+// mmq_write_back_mma requires nwarps * tile_C::I == mmq_y. On gfx1151,
+// 64 rows and 4 warps reduce LDS staging stalls compared with 128/8.
 static int get_mmq_y_host(const int cc) {
+    if (GGML_CUDA_CC_IS_RDNA3_5(cc)) {
+        return 64;
+    }
     return GGML_CUDA_CC_IS_AMD(cc) ? (GGML_CUDA_CC_IS_RDNA1(cc) ? 64 : 128) :
         ((GGML_CUDA_CC_IS_NVIDIA(cc) && ggml_cuda_highest_compiled_arch(cc) >= GGML_CUDA_CC_VOLTA) ? 128 : 64);
 }
@@ -162,7 +168,9 @@ if (type == GGML_TYPE_NVFP4 || type == GGML_TYPE_MXFP4) {
 
 static constexpr __device__ int get_mmq_y_device() {
 #if defined(GGML_USE_HIP)
-#if defined(RDNA1)
+#if defined(RDNA3_5)
+    return 64;
+#elif defined(RDNA1)
     return 64;
 #else
     return 128;
@@ -325,6 +333,10 @@ static constexpr __device__ int mmq_get_granularity_device(const int /*mmq_x*/) 
 
 #if defined(GGML_USE_HIP)
 static int mmq_get_nwarps_host(const int cc, const int warp_size) {
+    // Coupled to get_mmq_y_* above.
+    if (GGML_CUDA_CC_IS_RDNA3_5(cc)) {
+        return 4;
+    }
     return amd_mfma_available(cc) ? 8 : 256/warp_size;
 }
 #else
@@ -334,7 +346,9 @@ static int mmq_get_nwarps_host(const int /*cc*/, const int warp_size) {
 #endif // (GGML_USE_HIP)
 
 static constexpr __device__ int mmq_get_nwarps_device() {
-#if defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
+#if defined(RDNA3_5)
+    return 4;
+#elif defined(AMD_MFMA_AVAILABLE) || defined(AMD_WMMA_AVAILABLE)
     return 8;
 #else
     return 256/ggml_cuda_get_physical_warp_size();


### PR DESCRIPTION
## Summary

- Extract the exact, default behavior-safe gfx1151 MMQ geometry improvement from draft PR #94.
- Use the coupled 64-row / 4-warp configuration required by the MMQ write-back invariant.
- Leave every non-RDNA3.5 architecture unchanged.
- Include no IU4/W4A4 activation approximation or format changes.

## Why it is faster

For Q4_0_ROCMI4 pp512, the launch changes from 256-thread to 128-thread blocks while preserving total work. Calculated dynamic shared memory per block falls from 56.5 KiB to 37.5 KiB. rocprofv3 measured duration-weighted ALUStalledByLDS falling from 4.11% to 1.60%; the main MMQ kernel time fell from 3.679 s to 3.428 s across the same 1,600 dispatches.

## Validation on gfx1151

- Clean Release HIP/Vulkan build: pass
- Full ROCm GET_ROWS and MUL_MAT sweep: 1402/1402 pass
- Focused Q4_0_ROCMI4 sweep: 41/41 pass
- Balanced A/B/B/A pp512: baseline 429.02, tuned 462.05, tuned 462.10, baseline 428.32 t/s
- Mean pp512: 428.67 -> 462.08 t/s, +7.79%
- tg128: unchanged at 13.79-13.81 t/s
- Strict-MTP HumanEval first 10: aggregate decode 40.22 -> 41.56 t/s, +3.33%
- HumanEval outputs and token counts: byte-identical to the exact baseline
- Diff check: clean

## Safety and rollback

This PR is one isolated commit on top of main. It can be reverted independently with a normal git revert without removing ROCmI4 support or touching draft PR #94.

License remains MIT.

Co-authored work credit is preserved in the commit trailers.