### PR TITLE
rocm: load weights-only DSpark/DFlash drafts by sharing the target model vocab

### DIFF
--- a/src/llama-arch.cpp
+++ b/src/llama-arch.cpp
@@ -936,7 +936,7 @@ llm_arch llm_arch_from_string(const std::string & name) {
     if (name == "gemma4-assistant") {
         return LLM_ARCH_GEMMA4_ASSISTANT;
     }
-    if (name == "dflash-draft") {
+    if (name == "dflash-draft" || name == "deepseek4-dflash-draft") {
         return LLM_ARCH_DFLASH;
     }
 

--- a/src/llama-ext.h
+++ b/src/llama-ext.h
@@ -92,6 +92,9 @@ struct llama_device_memory_data {
 using llama_memory_breakdown = std::map<ggml_backend_buffer_type_t, llama_memory_breakdown_data>;
 
 LLAMA_API int32_t llama_model_n_expert (const struct llama_model * model);
+
+// Share the source model's vocab with the destination model (e.g. vocab-less DFlash drafts).
+LLAMA_API void llama_model_share_vocab(struct llama_model * dst, const struct llama_model * src);
 LLAMA_API int32_t llama_model_n_devices(const struct llama_model * model);
 
 LLAMA_API ggml_backend_dev_t llama_model_get_device(const struct llama_model * model, int i);

--- a/src/llama-model-loader.cpp
+++ b/src/llama-model-loader.cpp
@@ -290,9 +290,14 @@ static std::string llama_model_loader_compat_key(const std::string & key) {
         compat_key.replace(0, std::string("gemma4_assistant").size(), "gemma4-assistant");
         return compat_key;
     }
+    if (key.rfind("deepseek4-dflash-draft.", 0) == 0) {
+        std::string compat_key = key;
+        compat_key.replace(0, std::string("deepseek4-dflash-draft").size(), "dflash-draft");
+        return compat_key;
+    }
     if (key.rfind("dflash.", 0) == 0) {
         std::string compat_key = key;
-        compat_key.replace(0, std::string("dflash").size(), "dflash-draft");
+        compat_key.replace(0, std::string("dflash").size(), "deepseek4-dflash-draft");
         return compat_key;
     }
     return {};
@@ -1144,8 +1149,20 @@ struct ggml_tensor * llama_model_loader::create_tensor(
             }
         } else if (load_name == "fc.weight" && get_tensor_meta("dflash_fc.weight") != nullptr) {
             load_name = "dflash_fc.weight";
+        } else if (load_name == "fc.weight" && get_tensor_meta("dflash.fc.weight") != nullptr) {
+            load_name = "dflash.fc.weight";
         } else if (load_name == "enc.output_norm.weight" && get_tensor_meta("dflash_hidden_norm.weight") != nullptr) {
             load_name = "dflash_hidden_norm.weight";
+        } else if (load_name == "enc.output_norm.weight" && get_tensor_meta("dflash.hidden_norm.weight") != nullptr) {
+            load_name = "dflash.hidden_norm.weight";
+        } else if (load_name == "markov_w1.weight" && get_tensor_meta("dflash.dspark.markov.w1") != nullptr) {
+            load_name = "dflash.dspark.markov.w1";
+        } else if (load_name == "markov_w2.weight" && get_tensor_meta("dflash.dspark.markov.w2") != nullptr) {
+            load_name = "dflash.dspark.markov.w2";
+        } else if (load_name == "conf_proj.weight" && get_tensor_meta("dflash.dspark.confidence.weight") != nullptr) {
+            load_name = "dflash.dspark.confidence.weight";
+        } else if (load_name == "conf_proj.bias" && get_tensor_meta("dflash.dspark.confidence.bias") != nullptr) {
+            load_name = "dflash.dspark.confidence.bias";
         } else {
             std::string compat_name = load_name;
             const std::string from = ".ffn_norm.";

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1022,7 +1022,7 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
         return;
     }
 
-    ml.get_key(LLM_KV_CONTEXT_LENGTH,          hparams.n_ctx_train);
+    ml.get_key(LLM_KV_CONTEXT_LENGTH,          hparams.n_ctx_train, false);
     ml.get_key(LLM_KV_EMBEDDING_LENGTH,        hparams.n_embd);
     ml.get_key(LLM_KV_EMBEDDING_LENGTH_OUT,    hparams.n_embd_out_impl, false);
     ml.get_key(LLM_KV_ATTENTION_CAUSAL,        hparams.causal_attn,     false);
@@ -2272,6 +2272,10 @@ llama_model_params llama_model_default_params() {
 
 const llama_vocab * llama_model_get_vocab(const llama_model * model) {
     return &model->vocab;
+}
+
+void llama_model_share_vocab(llama_model * dst, const llama_model * src) {
+    dst->vocab.copy_from(src->vocab);
 }
 
 void llama_free_model(llama_model * model) {

--- a/src/llama-vocab.cpp
+++ b/src/llama-vocab.cpp
@@ -1905,7 +1905,9 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
 
     // determine vocab type
     {
-        ml.get_key(LLM_KV_TOKENIZER_MODEL, tokenizer_model);
+        if (!ml.get_key(LLM_KV_TOKENIZER_MODEL, tokenizer_model, false)) {
+            tokenizer_model = "no_vocab";
+        }
         ml.get_key(LLM_KV_TOKENIZER_PRE,   tokenizer_pre, false);
 
         ml.get_key(LLM_KV_TOKENIZER_TOKEN_TYPE_COUNT, n_token_types, false);
@@ -3731,6 +3733,55 @@ void llama_vocab::impl::print_info() const {
     }
 
     LLAMA_LOG_INFO("%s: max token length      = %d\n", __func__, max_token_len);
+}
+
+void llama_vocab::copy_from(const llama_vocab & other) {
+    // Member-wise copy; the reference member 'vocab' is fixed at construction.
+    auto & dst = *pimpl;
+    const auto & src = *other.pimpl;
+
+    dst.n_token_types            = src.n_token_types;
+    dst.tokenizer_model          = src.tokenizer_model;
+    dst.tokenizer_pre            = src.tokenizer_pre;
+    dst.type                     = src.type;
+    dst.pre_type                 = src.pre_type;
+    dst.max_token_len            = src.max_token_len;
+    dst.special_bos_id           = src.special_bos_id;
+    dst.special_eos_id           = src.special_eos_id;
+    dst.special_eot_id           = src.special_eot_id;
+    dst.special_eom_id           = src.special_eom_id;
+    dst.special_unk_id           = src.special_unk_id;
+    dst.special_sep_id           = src.special_sep_id;
+    dst.special_pad_id           = src.special_pad_id;
+    dst.special_mask_id          = src.special_mask_id;
+    dst.linefeed_id              = src.linefeed_id;
+    dst.special_fim_pre_id       = src.special_fim_pre_id;
+    dst.special_fim_suf_id       = src.special_fim_suf_id;
+    dst.special_fim_mid_id       = src.special_fim_mid_id;
+    dst.special_fim_pad_id       = src.special_fim_pad_id;
+    dst.special_fim_rep_id       = src.special_fim_rep_id;
+    dst.special_fim_sep_id       = src.special_fim_sep_id;
+    dst.add_space_prefix         = src.add_space_prefix;
+    dst.add_bos                  = src.add_bos;
+    dst.add_eos                  = src.add_eos;
+    dst.add_sep                  = src.add_sep;
+    dst.ignore_merges            = src.ignore_merges;
+    dst.clean_spaces             = src.clean_spaces;
+    dst.remove_extra_whitespaces = src.remove_extra_whitespaces;
+    dst.escape_whitespaces       = src.escape_whitespaces;
+    dst.treat_whitespace_as_suffix = src.treat_whitespace_as_suffix;
+    dst.normalizer_opts          = src.normalizer_opts;
+    dst.token_to_id              = src.token_to_id;
+    dst.id_to_token              = src.id_to_token;
+    dst.cache_special_tokens     = src.cache_special_tokens;
+    dst.cache_token_to_piece     = src.cache_token_to_piece;
+    dst.bpe_ranks                = src.bpe_ranks;
+    dst.special_eog_ids          = src.special_eog_ids;
+    dst.suppress_tokens          = src.suppress_tokens;
+    dst.precompiled_charsmap     = src.precompiled_charsmap;
+
+    dst.tokenizer.reset();
+    dst.init_tokenizer(dst.type);
 }
 
 llama_vocab::llama_vocab() : pimpl(new impl(*this)) {

--- a/src/llama-vocab.h
+++ b/src/llama-vocab.h
@@ -85,6 +85,7 @@ struct llama_vocab {
     ~llama_vocab();
 
     void load(llama_model_loader & ml, const LLM_KV & kv);
+    void copy_from(const llama_vocab & other);
 
     std::string get_tokenizer_model() const;
     std::string get_tokenizer_pre() const;

--- a/src/models/dflash.cpp
+++ b/src/models/dflash.cpp
@@ -11,8 +11,10 @@ void llama_model_dflash::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);
 
     if (!ml.get_arr(LLM_KV_TARGET_LAYERS, target_layer_ids, false) &&
-        !ml.get_arr("dflash.dflash.target_layer_ids", target_layer_ids, false)) {
-        throw std::runtime_error("DFlash model requires 'target_layers' or 'dflash.target_layer_ids' in GGUF metadata");
+        !ml.get_arr("dflash.dflash.target_layer_ids", target_layer_ids, false) &&
+        !ml.get_arr("dflash.capture_layer_ids", target_layer_ids, false) &&
+        !ml.get_arr("deepseek4-dflash-draft.dflash.capture_layer_ids", target_layer_ids, false)) {
+        throw std::runtime_error("DFlash model requires 'target_layers', 'dflash.target_layer_ids', or 'dflash.capture_layer_ids' in GGUF metadata");
     }
 
     // The encoder fc fuses the extracted target hidden states, so its input width is
@@ -25,6 +27,7 @@ void llama_model_dflash::load_arch_hparams(llama_model_loader & ml) {
     LLAMA_LOG_INFO("%s: DFlash n_embd_tgt = %u (draft n_embd = %u)\n", __func__, n_embd_tgt, hparams.n_embd);
 
     LLAMA_LOG_INFO("%s: DFlash extract_layers = [", __func__);
+    if (hparams.n_ctx_train == 0) hparams.n_ctx_train = 4096;
     for (size_t i = 0; i < target_layer_ids.size(); ++i) {
         LLAMA_LOG_INFO("%d%s", target_layer_ids[i], i + 1 < target_layer_ids.size() ? ", " : "");
     }
@@ -35,13 +38,28 @@ void llama_model_dflash::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_HYPER_CONNECTION_COUNT, hparams.n_hc, false);
     if (hparams.n_hc > 1) {
         ml.get_key(LLM_KV_ATTENTION_Q_LORA_RANK,       hparams.n_lora_q);
-        ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW,    hparams.n_swa);
+        if (!ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW, hparams.n_swa, false)) {
+            hparams.n_swa = 4096;
+        }
         ml.get_key(LLM_KV_EXPERT_FEED_FORWARD_LENGTH,  hparams.n_ff_exp);
         ml.get_key(LLM_KV_EXPERT_SHARED_COUNT,         hparams.n_expert_shared);
         ml.get_key(LLM_KV_EXPERT_WEIGHTS_SCALE,        hparams.expert_weights_scale);
-        ml.get_key(LLM_KV_EXPERT_WEIGHTS_NORM,         hparams.expert_weights_norm);
-        ml.get_key(LLM_KV_EXPERT_GATING_FUNC,          hparams.expert_gating_func);
-        ml.get_key_or_arr(LLM_KV_SWIGLU_CLAMP_EXP,     hparams.swiglu_clamp_exp, hparams.n_layer);
+        if (!ml.get_key(LLM_KV_EXPERT_WEIGHTS_NORM,    hparams.expert_weights_norm, false)) {
+            hparams.expert_weights_norm = 1.0f;
+        }
+        std::string gating_str;
+        if (ml.get_key(LLM_KV_EXPERT_GATING_FUNC, gating_str, false) && gating_str == "softmax") {
+            hparams.expert_gating_func = LLAMA_EXPERT_GATING_FUNC_TYPE_SOFTMAX;
+        } else if (ml.get_key(LLM_KV_EXPERT_GATING_FUNC, gating_str, false) && gating_str == "sigmoid") {
+            hparams.expert_gating_func = LLAMA_EXPERT_GATING_FUNC_TYPE_SIGMOID;
+        } else if (ml.get_key(LLM_KV_EXPERT_GATING_FUNC, gating_str, false) && gating_str == "sqrtsoftplus") {
+            hparams.expert_gating_func = LLAMA_EXPERT_GATING_FUNC_TYPE_SQRTSOFTPLUS;
+        } else if (!ml.get_key(LLM_KV_EXPERT_GATING_FUNC, hparams.expert_gating_func, false)) {
+            hparams.expert_gating_func = LLAMA_EXPERT_GATING_FUNC_TYPE_SQRTSOFTPLUS;
+        }
+        if (!ml.get_key_or_arr(LLM_KV_SWIGLU_CLAMP_EXP, hparams.swiglu_clamp_exp, hparams.n_layer, false)) {
+            std::fill(hparams.swiglu_clamp_exp.begin(), hparams.swiglu_clamp_exp.end(), 1.0f);
+        }
         if (!ml.get_key_or_arr(LLM_KV_SWIGLU_CLAMP_SHEXP, hparams.swiglu_clamp_shexp, hparams.n_layer, false)) {
             hparams.swiglu_clamp_shexp = hparams.swiglu_clamp_exp;
         }
@@ -106,6 +124,7 @@ void llama_model_dflash::load_arch_tensors(llama_model_loader & ml) {
 
     // DSpark adds a Markov bias and a per-position confidence head to DFlash.
     const struct ggml_tensor * markov_meta = ml.get_tensor_meta("markov_w1.weight");
+    if (!markov_meta) markov_meta = ml.get_tensor_meta("dflash.dspark.markov.w1");
     if (markov_meta) {
         const int64_t dspark_markov_rank = markov_meta->ne[0];
 
@@ -301,6 +320,9 @@ static void build_dspark_markov_head(llm_graph_context & g, const llama_model & 
     auto it = model.gguf_kv.find("dflash.block_size");
     if (it == model.gguf_kv.end()) {
         it = model.gguf_kv.find("dflash-draft.dflash.block_size");
+    }
+    if (it == model.gguf_kv.end()) {
+        it = model.gguf_kv.find("deepseek4-dflash-draft.dflash.block_size");
     }
     GGML_ASSERT(it != model.gguf_kv.end() && "DSpark draft requires dflash.block_size metadata");
     const int64_t block_size = std::stoi(it->second);

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -896,6 +896,11 @@ private:
                 return false;
             }
 
+            // DSpark/DFlash drafts from Lucebox may ship weights-only (no tokenizer); share the target's vocab
+            if (llama_vocab_type(llama_model_get_vocab(model_dft.get())) == LLAMA_VOCAB_TYPE_NONE) {
+                llama_model_share_vocab(model_dft.get(), model_tgt);
+            }
+
             auto cparams = common_context_params_to_llama(params_dft);
 
             const bool spec_mtp = std::find(params_base.speculative.types.begin(),


### PR DESCRIPTION
Draft models built from `deepseek4-dflash` GGUF files may ship **weights-only** (no tokenizer in their GGUF metadata). Loading them as speculative drafters currently fails: the loader requires a tokenizer, and several tensor names / arch aliases don't match the `deepseek4-dflash-draft` layout.

## Changes
- `llama_vocab::copy_from()` + `llama_model_share_vocab()` — a vocab-less draft inherits the target model's vocab in the server (`no_vocab` tokenizer type tolerated at load).
- `deepseek4-dflash-draft` recognized as an alias for the `dflash` arch, with tensor-name compat mappings (`dflash.fc.weight`, `dflash.hidden_norm.weight`, `dflash.dspark.markov.w1/w2`, `dflash.dspark.confidence.weight/bias`).
- Tolerant hparam defaults in the DFlash load path (ctx / swa / expert-norm / gating / clamp) so incomplete GGUF metadata loads instead of throwing.

## Notes
- This targets the **v1** DFlash/DSpark draft layout and is independent of the DFlash2 (v2) work in #90 — no overlap.
- Fixes the *vocab-less draft* load failure reported in **#44**.

## Verification
- Incremental rebuild of `llama-server` from the pre-configured `build-vk` tree: **clean, exit 0**.
- `llama_model_share_vocab` symbol present in the linked binary.