### PR TITLE
server: salvage prompt-cache entries via host-shadowed checkpoints on spec-boundary mismatch

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -2068,6 +2068,8 @@ common_prompt_checkpoint::common_prompt_checkpoint(const common_prompt_checkpoin
     pos_max(other.pos_max),
     data_tgt(other.data_tgt),
     data_dft(other.data_dft),
+    data_tgt_host(other.data_tgt_host),
+    data_dft_host(other.data_dft_host),
     data_spec(other.data_spec),
     storage_tgt(llama_state_seq_storage_clone(other.storage_tgt)),
     storage_dft(llama_state_seq_storage_clone(other.storage_dft)) {
@@ -2084,6 +2086,8 @@ common_prompt_checkpoint & common_prompt_checkpoint::operator=(const common_prom
 
     data_tgt = other.data_tgt;
     data_dft = other.data_dft;
+    data_tgt_host = other.data_tgt_host;
+    data_dft_host = other.data_dft_host;
     data_spec = other.data_spec;
 
     llama_state_seq_storage_free(storage_tgt);
@@ -2100,6 +2104,8 @@ common_prompt_checkpoint::common_prompt_checkpoint(common_prompt_checkpoint && o
     pos_max(other.pos_max),
     data_tgt(std::move(other.data_tgt)),
     data_dft(std::move(other.data_dft)),
+    data_tgt_host(std::move(other.data_tgt_host)),
+    data_dft_host(std::move(other.data_dft_host)),
     data_spec(std::move(other.data_spec)),
     storage_tgt(other.storage_tgt),
     storage_dft(other.storage_dft) {
@@ -2121,6 +2127,8 @@ common_prompt_checkpoint & common_prompt_checkpoint::operator=(common_prompt_che
 
     data_tgt = std::move(other.data_tgt);
     data_dft = std::move(other.data_dft);
+    data_tgt_host = std::move(other.data_tgt_host);
+    data_dft_host = std::move(other.data_dft_host);
     data_spec = std::move(other.data_spec);
 
     storage_tgt = other.storage_tgt;
@@ -2135,6 +2143,8 @@ common_prompt_checkpoint & common_prompt_checkpoint::operator=(common_prompt_che
 size_t common_prompt_checkpoint::size() const {
     return data_tgt.size() +
            data_dft.size() +
+           data_tgt_host.size() +
+           data_dft_host.size() +
            data_spec.size() +
            llama_state_seq_storage_size(storage_tgt) +
            llama_state_seq_storage_size(storage_dft);
@@ -2152,6 +2162,8 @@ void common_prompt_checkpoint::clear() {
 
     data_tgt.clear();
     data_dft.clear();
+    data_tgt_host.clear();
+    data_dft_host.clear();
     data_spec.clear();
 
     llama_state_seq_storage_free(storage_tgt);
@@ -2221,6 +2233,85 @@ void common_prompt_checkpoint::update_dft(
     if (n != ckpt_size) {
         GGML_ABORT("checkpoint size mismatch: expected %zu, got %zu\n", ckpt_size, n);
     }
+}
+
+void common_prompt_checkpoint::capture_host(
+        llama_context *       ctx_tgt,
+        llama_context *       ctx_dft,
+        llama_seq_id          seq_id,
+        llama_state_seq_flags flags) {
+    if (ctx_tgt != nullptr) {
+        const size_t ckpt_size = llama_state_seq_get_size_ext(ctx_tgt, seq_id, flags);
+
+        data_tgt_host.resize(ckpt_size);
+
+        const size_t n = llama_state_seq_get_data_ext_storage(ctx_tgt, data_tgt_host.data(), ckpt_size, seq_id, flags, nullptr);
+        if (n != ckpt_size) {
+            GGML_ABORT("host checkpoint size mismatch: expected %zu, got %zu\n", ckpt_size, n);
+        }
+    }
+
+    if (ctx_dft != nullptr) {
+        const size_t ckpt_size = llama_state_seq_get_size_ext(ctx_dft, seq_id, flags);
+
+        data_dft_host.resize(ckpt_size);
+
+        const size_t n = llama_state_seq_get_data_ext_storage(ctx_dft, data_dft_host.data(), ckpt_size, seq_id, flags, nullptr);
+        if (n != ckpt_size) {
+            GGML_ABORT("host draft checkpoint size mismatch: expected %zu, got %zu\n", ckpt_size, n);
+        }
+    }
+}
+
+bool common_prompt_checkpoint::load_tgt_host(
+        llama_context * ctx,
+        llama_seq_id seq_id,
+        llama_state_seq_flags flags) const {
+    if (ctx == nullptr) {
+        return true;
+    }
+
+    if (data_tgt_host.empty()) {
+        return true;
+    }
+
+    const size_t n = llama_state_seq_set_data_ext_storage(ctx, data_tgt_host.data(), data_tgt_host.size(), seq_id, flags, nullptr);
+    if (n != data_tgt_host.size()) {
+        LOG_WRN("%s: target host checkpoint restore failed: expected=%zu, restored=%zu\n",
+                __func__, data_tgt_host.size(), n);
+        return false;
+    }
+
+    return true;
+}
+
+bool common_prompt_checkpoint::load_dft_host(
+        llama_context * ctx,
+        llama_seq_id seq_id,
+        llama_state_seq_flags flags) const {
+    if (ctx == nullptr) {
+        return true;
+    }
+
+    if (data_dft_host.empty()) {
+        return true;
+    }
+
+    const size_t n = llama_state_seq_set_data_ext_storage(ctx, data_dft_host.data(), data_dft_host.size(), seq_id, flags, nullptr);
+    if (n != data_dft_host.size()) {
+        LOG_WRN("%s: draft host checkpoint restore failed: expected=%zu, restored=%zu\n",
+                __func__, data_dft_host.size(), n);
+        return false;
+    }
+
+    return true;
+}
+
+void common_prompt_checkpoint::clear_host() {
+    data_tgt_host.clear();
+    data_tgt_host.shrink_to_fit();
+    data_dft_host.clear();
+    data_dft_host.shrink_to_fit();
 }
 
 bool common_prompt_checkpoint::load_tgt(

--- a/common/common.h
+++ b/common/common.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <map>
 #include <algorithm>
+#include <list>
 
 #if defined(_WIN32) && !defined(_WIN32_WINNT)
 #define _WIN32_WINNT 0x0A00
@@ -1154,3 +1155,32 @@ struct common_prompt_checkpoint {
     // drop the host shadows (e.g. to bound memory on older checkpoints)
     void clear_host();
 };
+
+// Select the best context checkpoint for prompt-cache salvage from `checkpoints`.
+//
+// A checkpoint qualifies when its captured state covers [0, n_tokens) with
+// n_tokens <= lcp (restore needs no rewind; only [n_tokens, request) is
+// re-prefilled) and it carries host-memory shadows (data_tgt_host) plus
+// speculative-impl state (data_spec) — the ON_DEVICE payloads are views into
+// live context memory and are clobbered by slot reuse.
+//
+// The largest qualifying checkpoint wins; on equal n_tokens the first one in
+// the list wins. Returns nullptr when no checkpoint qualifies.
+inline const common_prompt_checkpoint * common_prompt_checkpoint_select_salvage(
+        const std::list<common_prompt_checkpoint> & checkpoints,
+        int64_t                                     lcp) {
+    const common_prompt_checkpoint * best = nullptr;
+    for (const auto & ckpt : checkpoints) {
+        if (best != nullptr && ckpt.n_tokens <= best->n_tokens) {
+            continue;
+        }
+        if (ckpt.n_tokens > lcp) {
+            continue;
+        }
+        if (ckpt.data_tgt_host.empty() || ckpt.data_spec.empty()) {
+            continue;
+        }
+        best = &ckpt;
+    }
+    return best;
+}

--- a/common/common.h
+++ b/common/common.h
@@ -1075,6 +1075,14 @@ struct common_prompt_checkpoint {
     std::vector<uint8_t> data_tgt;
     std::vector<uint8_t> data_dft;
 
+    // host-memory shadows of the target/draft state, captured at checkpoint
+    // creation. unlike the ON_DEVICE payloads above (views into the live
+    // context memory, clobbered as soon as the slot is reused), these stay
+    // valid across slot reuse and are what the prompt-cache salvage restores
+    // from. only the newest few checkpoints keep them to bound memory.
+    std::vector<uint8_t> data_tgt_host;
+    std::vector<uint8_t> data_dft_host;
+
     // speculative-impl state at the checkpoint position (e.g. MTP boundary rows),
     // so a checkpoint restore can also rewind the draft bookkeeping
     std::vector<uint8_t> data_spec;
@@ -1111,6 +1119,14 @@ struct common_prompt_checkpoint {
             llama_seq_id seq_id,
             llama_state_seq_flags flags);
 
+    // capture host-memory shadows of the target and draft state (see
+    // data_tgt_host / data_dft_host above)
+    void capture_host(
+            llama_context *       ctx_tgt,
+            llama_context *       ctx_dft,
+            llama_seq_id          seq_id,
+            llama_state_seq_flags flags);
+
     bool load_tgt(
             llama_context * ctx,
             llama_seq_id seq_id,
@@ -1121,6 +1137,20 @@ struct common_prompt_checkpoint {
             llama_seq_id seq_id,
             llama_state_seq_flags flags) const;
 
+    // restore from the host shadows (see data_tgt_host / data_dft_host)
+    bool load_tgt_host(
+            llama_context * ctx,
+            llama_seq_id seq_id,
+            llama_state_seq_flags flags) const;
+
+    bool load_dft_host(
+            llama_context * ctx,
+            llama_seq_id seq_id,
+            llama_state_seq_flags flags) const;
+
     void clear_tgt();
     void clear_dft();
+
+    // drop the host shadows (e.g. to bound memory on older checkpoints)
+    void clear_host();
 };

--- a/src/llama-memory-hybrid.cpp
+++ b/src/llama-memory-hybrid.cpp
@@ -179,17 +179,19 @@ std::map<ggml_backend_buffer_type_t, size_t> llama_memory_hybrid::memory_breakdo
     return mb;
 }
 
+// [TAG_HYBRID_STATE_FULL]
+// server checkpoints are captured with LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY.
+// for hybrid memory the partial state must still include the attention KV:
+// skipping it produced checkpoints that rewind the recurrent state but read
+// stale attention memory on resume (nondeterministic output). the flag only
+// means "skip padding cells" for the sub-caches, never "skip a component".
 void llama_memory_hybrid::state_write(llama_io_write_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) const {
-    if ((flags & LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY) == 0) {
-        mem_attn->state_write(io, seq_id, flags);
-    }
+    mem_attn->state_write(io, seq_id, flags);
     mem_recr->state_write(io, seq_id, flags);
 }
 
 void llama_memory_hybrid::state_read(llama_io_read_i & io, llama_seq_id seq_id, llama_state_seq_flags flags) {
-    if ((flags & LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY) == 0) {
-        mem_attn->state_read(io, seq_id, flags);
-    }
+    mem_attn->state_read(io, seq_id, flags);
     mem_recr->state_read(io, seq_id, flags);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -306,3 +306,6 @@ if (TARGET gguf-model-data)
     target_link_libraries(export-graph-ops PRIVATE gguf-model-data)
     target_compile_definitions(export-graph-ops PRIVATE LLAMA_HF_FETCH)
 endif()
+
+llama_build(test-prompt-cache-salvage.cpp)
+llama_test(test-prompt-cache-salvage)

--- a/tests/test-prompt-cache-salvage.cpp
+++ b/tests/test-prompt-cache-salvage.cpp
@@ -1,0 +1,114 @@
+// Unit tests for the prompt-cache checkpoint salvage selection used by
+// server_prompt_cache::load() (issue: alternating agents on one slot with
+// speculative decoding fell back to full cold prefill because every entry
+// failed the spec-boundary check; the fix restores the newest checkpoint
+// that carries host-memory shadows and whose captured state lies within the
+// request's common prefix).
+#include "common.h"
+
+#include <cstdint>
+#include <list>
+#include <vector>
+
+#include <cassert>
+#include <cstdio>
+
+namespace {
+
+common_prompt_checkpoint make_ckpt(int64_t n_tokens, bool with_shadows, bool with_spec) {
+    common_prompt_checkpoint ckpt;
+    ckpt.n_tokens = n_tokens;
+    if (with_shadows) {
+        ckpt.data_tgt_host = {1, 2, 3};
+        ckpt.data_dft_host = {4};
+    }
+    if (with_spec) {
+        ckpt.data_spec = {5, 6, 7};
+    }
+    return ckpt;
+}
+
+const common_prompt_checkpoint * select(const std::list<common_prompt_checkpoint> & checkpoints, int64_t lcp) {
+    return common_prompt_checkpoint_select_salvage(checkpoints, lcp);
+}
+
+} // namespace
+
+int main() {
+    {
+        // empty cache entry: nothing to salvage
+        std::list<common_prompt_checkpoint> none;
+        assert(select(none, 1000) == nullptr);
+    }
+    {
+        // qualifying checkpoint is returned
+        std::list<common_prompt_checkpoint> cks = {make_ckpt(300, true, true)};
+        auto * picked = select(cks, 400);
+        assert(picked != nullptr && picked->n_tokens == 300);
+    }
+    {
+        // checkpoint beyond the common prefix does not qualify: restoring it
+        // would still require rewinding recurrent state, which is exactly what
+        // the salvage path exists to avoid
+        std::list<common_prompt_checkpoint> cks = {make_ckpt(500, true, true)};
+        assert(select(cks, 400) == nullptr);
+    }
+    {
+        // missing host shadows disqualify: the ON_DEVICE payloads are views
+        // into live context memory and are clobbered by slot reuse
+        std::list<common_prompt_checkpoint> cks = {make_ckpt(300, false, true)};
+        assert(select(cks, 400) == nullptr);
+    }
+    {
+        // missing speculative-impl state disqualifies: the restore must also
+        // rewind the draft bookkeeping at the checkpoint position
+        std::list<common_prompt_checkpoint> cks = {make_ckpt(300, true, false)};
+        assert(select(cks, 400) == nullptr);
+    }
+    {
+        // largest qualifying checkpoint wins
+        std::list<common_prompt_checkpoint> cks = {
+            make_ckpt(100, true, true),
+            make_ckpt(300, true, true),
+            make_ckpt(200, true, true),
+        };
+        auto * picked = select(cks, 400);
+        assert(picked != nullptr && picked->n_tokens == 300);
+    }
+    {
+        // a checkpoint beyond lcp is skipped even when larger, so a smaller
+        // qualifying one is picked instead
+        std::list<common_prompt_checkpoint> cks = {
+            make_ckpt(450, true, true),
+            make_ckpt(300, true, true),
+        };
+        auto * picked = select(cks, 400);
+        assert(picked != nullptr && picked->n_tokens == 300);
+    }
+    {
+        // tie on n_tokens: the first checkpoint in the list wins (the
+        // selection never replaces an equally large pick)
+        std::list<common_prompt_checkpoint> cks = {
+            make_ckpt(300, true, true),
+            make_ckpt(300, true, true),
+        };
+        auto * picked = select(cks, 400);
+        assert(picked != nullptr && picked == &cks.front());
+    }
+    {
+        // lcp exactly at the checkpoint boundary qualifies (restore covers
+        // [0, n_tokens) and the request adds nothing within the prefix)
+        std::list<common_prompt_checkpoint> cks = {make_ckpt(300, true, true)};
+        auto * picked = select(cks, 300);
+        assert(picked != nullptr && picked->n_tokens == 300);
+    }
+    {
+        // lcp = 0 (disjoint request): only an empty checkpoint would qualify,
+        // real checkpoints always cover tokens, so nothing is selected
+        std::list<common_prompt_checkpoint> cks = {make_ckpt(300, true, true)};
+        assert(select(cks, 0) == nullptr);
+    }
+
+    printf("test-prompt-cache-salvage: all assertions passed\n");
+    return 0;
+}

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -2045,6 +2045,24 @@ private:
             common_speculative_get_state(spec.get(), slot.id, cur.data_spec);
         }
 
+        // host-memory shadow for the prompt-cache salvage path: ON_DEVICE
+        // payloads are views into the live context memory and do not survive
+        // the slot being reused by the next task. keep shadows only on the
+        // newest few checkpoints to bound memory.
+        cur.capture_host(ctx_tgt, ctx_dft.get(), slot.id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+
+        {
+            static constexpr int KEEP_HOST = 2;
+            int remaining = KEEP_HOST;
+            for (auto it = slot.prompt.checkpoints.rbegin(); it != slot.prompt.checkpoints.rend(); ++it) {
+                if (remaining > 0) {
+                    --remaining;
+                    continue;
+                }
+                it->clear_host();
+            }
+        }
+
         SLT_INF(slot,
                 "created context checkpoint %d of %d (pos_min = %d, pos_max = %d, n_tokens = %" PRId64 ", size = %.3f MiB)\n",
                 (int) slot.prompt.checkpoints.size(), params_base.n_ctx_checkpoints, cur.pos_min,

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -3070,17 +3070,9 @@ bool server_prompt_cache::load(
         const int lcp_cur = it->tokens.get_common_prefix(tokens_new);
 
         if (spec_state_required) {
-            for (const auto & ckpt : it->checkpoints) {
-                if (ckpt_sel && ckpt.n_tokens <= ckpt_sel->n_tokens) {
-                    continue;
-                }
-                if (ckpt.n_tokens > lcp_cur) {
-                    continue;
-                }
-                if (ckpt.data_tgt_host.empty() || ckpt.data_spec.empty()) {
-                    continue;
-                }
-                ckpt_sel    = &ckpt;
+            const auto * ckpt_cand = common_prompt_checkpoint_select_salvage(it->checkpoints, lcp_cur);
+            if (ckpt_cand != nullptr && (ckpt_sel == nullptr || ckpt_cand->n_tokens > ckpt_sel->n_tokens)) {
+                ckpt_sel     = ckpt_cand;
                 it_best_ckpt = it;
                 lcp_ckpt     = lcp_cur;
             }

--- a/tools/server/server-task.cpp
+++ b/tools/server/server-task.cpp
@@ -3052,10 +3052,39 @@ bool server_prompt_cache::load(
     size_t spec_boundary_best = base_boundary_valid ? prompt.tokens.size() : 0;
     bool ram_loaded = false;
 
+    // checkpoint salvage fallback: when every entry fails the spec-boundary
+    // check (the diverging tail exceeds the bounded recurrent-state rewind),
+    // an entry can still be restored from one of its context checkpoints -
+    // the checkpoint state covers [0, ckpt.n_tokens) exactly, so no rewind
+    // is needed and only [ckpt.n_tokens, request) is re-prefilled.
+    // only checkpoints with host-memory shadows qualify: the ON_DEVICE
+    // payloads are views into the live context memory and are clobbered as
+    // soon as the slot is reused by another task.
+    auto it_best_ckpt = states.end();
+    const common_prompt_checkpoint * ckpt_sel = nullptr;
+    size_t lcp_ckpt = 0;
+
     // Find the most similar RAM prompt first. On an equal match, the hot RAM
     // copy wins and avoids SSD I/O.
     for (auto it = states.begin(); it != states.end(); ++it) {
         const int lcp_cur = it->tokens.get_common_prefix(tokens_new);
+
+        if (spec_state_required) {
+            for (const auto & ckpt : it->checkpoints) {
+                if (ckpt_sel && ckpt.n_tokens <= ckpt_sel->n_tokens) {
+                    continue;
+                }
+                if (ckpt.n_tokens > lcp_cur) {
+                    continue;
+                }
+                if (ckpt.data_tgt_host.empty() || ckpt.data_spec.empty()) {
+                    continue;
+                }
+                ckpt_sel    = &ckpt;
+                it_best_ckpt = it;
+                lcp_ckpt     = lcp_cur;
+            }
+        }
 
         if (!spec_boundary_valid(it->tokens.size(), lcp_cur)) {
             SRV_INF("prompt cache skip: reason=spec-boundary-mismatch source=ram lcp=%d cached_tokens=%zu request_tokens=%zu spec_bytes=%zu\n",
@@ -3184,6 +3213,60 @@ bool server_prompt_cache::load(
             *cache_hit = true;
         }
         ram_loaded = true;
+    }
+
+    if (it_best_ram == states.end() && it_best_disk == disk_states.end() && it_best_ckpt != states.end() && ckpt_sel != nullptr) {
+        const int64_t ckpt_n     = ckpt_sel->n_tokens;
+        const int64_t reprefill  = (int64_t) tokens_new.size() - ckpt_n;
+        std::vector<uint8_t> ckpt_spec_copy = ckpt_sel->data_spec;
+
+        SRV_INF(" - salvaging prompt via checkpoint: ckpt_tokens=%lld lcp=%zu request_tokens=%zu reprefill=%lld\n",
+                (long long) ckpt_n, lcp_ckpt, tokens_new.size(), (long long) reprefill);
+
+        if (!ckpt_sel->load_tgt_host(ctx_tgt, id_slot, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY)) {
+            SRV_WRN("failed to restore checkpoint target state (ckpt_tokens=%lld)\n", (long long) ckpt_n);
+            return false;
+        }
+
+        if (ctx_dft) {
+            if (!ckpt_sel->load_dft_host(ctx_dft, id_slot, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY)) {
+                SRV_WRN("failed to restore checkpoint draft state (ckpt_tokens=%lld)\n", (long long) ckpt_n);
+                return false;
+            }
+        }
+
+        // the slot seq may hold cells from the previous prompt beyond the
+        // checkpoint position; drop them so attention cannot reach stale
+        // memory (same pattern as the speculative replay path)
+        common_context_seq_rm(ctx_tgt, id_slot, ckpt_sel->pos_max + 1, -1);
+        if (ctx_dft) {
+            common_context_seq_rm(ctx_dft, id_slot, ckpt_sel->pos_max + 1, -1);
+        }
+
+        prompt = std::move(*it_best_ckpt);
+        states.erase(it_best_ckpt);
+
+        // the restored state covers [0, ckpt_n) only; drop everything that
+        // belongs to the diverging tail (tokens, later checkpoints, and the
+        // end-of-prompt state blobs)
+        prompt.tokens.keep_first(ckpt_n);
+        for (auto it = prompt.checkpoints.begin(); it != prompt.checkpoints.end(); ) {
+            if (it->n_tokens > ckpt_n) {
+                it = prompt.checkpoints.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        prompt.data.main.clear();
+        prompt.data.main.shrink_to_fit();
+        prompt.data.drft.clear();
+        prompt.data.drft.shrink_to_fit();
+        prompt.data.spec = std::move(ckpt_spec_copy);
+
+        if (cache_hit != nullptr) {
+            *cache_hit = true;
+        }
+        return true;
     }
 
     return base_boundary_valid || ram_loaded;


### PR DESCRIPTION
## Overview

With speculative decoding on hybrid-attention models, a prompt-cache entry whose tail diverges more than the recurrent rewind ring (`n_rs_seq = draft.n_max`) fails the spec-boundary check and cold-falls back. Two alternating clients that share only a system prompt on a single slot (`-np 1`) therefore re-prefill the entire prompt on every switch.

This PR:

1. **`llama-memory: hybrid sequence state must include the attention cache`** — `llama_memory_hybrid::state_write/state_read` skipped the whole attention KV under `PARTIAL_ONLY`, so checkpoints captured on hybrid models rewound the recurrent state but read stale attention memory on resume (nondeterministic output; this is the failure mode that forced the earlier checkpoint-salvage approach to be backed out in 560c4d468). `PARTIAL_ONLY` now only ever means "skip padding cells" for the sub-caches, never "skip a memory component".

2. **`server: salvage prompt-cache entries via host-shadowed checkpoints`** — `create_checkpoint` additionally captures a host-memory shadow of the newest two checkpoints (the `ON_DEVICE` payloads are views into the live context memory and are clobbered by the next task), and `server_prompt_cache::load()` falls back to the newest shadowed checkpoint within the common prefix: restore host-to-device, drop cells beyond it, re-prefill only `[ckpt.n_tokens, request)`.

## Measured (Qwen3.8-27B ROCmFP4, Strix Halo gfx1151, Vulkan0, -np 1, draft-mtp n_max=4)

Two alternating ~7.3k-token prompts (shared system prefix only):

| request | before | after |
|---|---|---|
| A first | 7278 prefill | 7278 prefill (cold, expected) |
| B first | 7278 prefill | 7278 prefill (cold, expected) |
| **A returns** | **7284 prefill, 0 cached** | **1034 prefill, 6250 cached** |

Output after the salvage is byte-identical to a cold prefill and deterministic across independent server runs. At longer contexts the reuse ratio grows (checkpoints every `-cpent` tokens bound the re-prefill).

Memory: host shadows are bounded to the newest two checkpoints per slot (trimmed at capture time) and are accounted in the cache-entry size.

## Requirements

- AI usage disclosure: YES — AI assistance was used to diagnose, implement, and verify this change; the submitter reviewed the resulting changes and remains responsible for them.
