### PR TITLE
fix: handle 0-free-VRAM report from ROCm backend

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1230,6 +1230,12 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
             if (free == 0 && total == 0) {
                 ggml_backend_dev_memory(cpu_dev, &free, &total);
             }
+            // ROCm can report 0 free VRAM on discrete GPUs (e.g. 7900 XTX)
+            // even when memory is available. Use total as fallback to
+            // avoid NaN in the split normalization (causes vector::at OOB).
+            if (free == 0 && total > 0) {
+                free = total;
+            }
             splits[i] = free;
         }
     } else {


### PR DESCRIPTION
## Problem

When using the ROCm (HIP) backend on discrete GPUs, `llama-server` crashes during model loading with:

```
vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)
```

This happens on AMD RX 7900 XTX (gfx1100, 24 GiB) with ROCm 10.0.0, but the bug is not hardware-specific — it triggers on **any** ROCm device that reports `0` bytes free VRAM at load time.

### Root cause

In `src/llama-model.cpp`, `llama_model_base::load_tensors()` computes per-device split weights from reported free memory:

```cpp
splits[i] = free;
```

These are then normalized:

```cpp
float split_sum = 0.0f;
for (size_t i = 0; i < n_devices(); ++i) {
    split_sum += splits[i];
    splits[i] = split_sum;
}
for (size_t i = 0; i < n_devices(); ++i) {
    splits[i] /= split_sum;   // ← NaN when split_sum == 0
}
```

When ROCm reports `free = 0` (but `total > 0`), `split_sum` stays `0`, and the division produces `NaN`. The existing fallback only covers `free == 0 && total == 0` (device reports nothing at all):

```cpp
if (free == 0 && total == 0) {
    ggml_backend_dev_memory(cpu_dev, &free, &total);
}
```

It does **not** cover the ROCm case where `total` is reported but `free` is zero — a common state on ROCm when VRAM is allocated by another process or when the driver reports total-only.

With `splits` containing `NaN`, the layer-to-device assignment via `std::upper_bound` returns the end iterator:

```cpp
const int layer_gpu = std::upper_bound(
    splits.begin(), splits.begin() + n_devices(),
    float(il - i_gpu_start) / act_gpu_layers
) - splits.begin();
auto * dev = devices.at(layer_gpu).dev;  // ← throws: layer_gpu == n_devices()
```

On a single-GPU system (`devices.size() == 1`), `layer_gpu` becomes `1`, and `devices.at(1)` throws `std::out_of_range` — the `vector::_M_range_check` error.

### Why ROCm reports 0 free

The ROCm HIP runtime reports `0 MiB free` on the 7900 XTX when:
- Vulkan0 backend is also registered (shares the same physical GPU)
- Another process holds VRAM allocations
- The driver reports `total` but not current `free` via `hipMemGetInfo`

This is observable in the startup logs:

```
- ROCm0   : AMD Radeon RX 7900 XTX (24560 MiB, 0 MiB free)
- Vulkan0 : AMD Radeon RX 7900 XTX (RADV NAVI31) (24560 MiB, 16082 MiB free)
```

## Fix

Add a fallback for the case where `free == 0` but `total > 0` — use `total` as the split weight:

```cpp
if (free == 0 && total > 0) {
    free = total;
}
splits[i] = free;
```

This ensures `split_sum > 0`, so normalization produces valid split points, and `std::upper_bound` returns a valid device index.

The fix is conservative: it only changes behavior when the existing code path would have crashed. When `free > 0`, the split is computed exactly as before.

## Verification

### Reproduction

- **Model:** Qwen3.8-27B GSQ-RCO IQ3_XXS (3.0 bpw, mixed IQ1_S/IQ1_M/IQ2_S/IQ3_XXS/IQ4_XS quants)
- **GPU:** AMD RX 7900 XTX (gfx1100, 24 GiB)
- **ROCm:** 10.0.0 (HIP 7.15.26333)
- **Commit:** `c49ebdbd` (current main)

Without the patch, `llama-server -dev ROCm0 -ngl 999 -c 4096` crashes during `load_tensors` with `vector::_M_range_check`. Tested with context sizes 262144, 200000, and 4096 — all fail identically. The Vulkan0 backend loads the same model successfully, confirming the issue is ROCm-backend-specific.

### After patch

Built `rocmfpx:git-c49ebdbd-rocm10.0.0` with the patch applied. ROCm0 loads and serves the model:

```
- ROCm0   : AMD Radeon RX 7900 XTX (24560 MiB, 0 MiB free)
...
srv    load_model: model loaded
srv          main: server is listening on http://0.0.0.0:9001
```

### Performance comparison (ROCm0 vs Vulkan0 fallback)

| Metric | Vulkan0 (before) | ROCm0 (after patch) | Speedup |
|---|---|---|---|
| Generation | 18.5 tok/s | 35.5 tok/s | 1.9× |
| Prompt processing | 61 tok/s | 143 tok/s | 2.3× |

Benchmark: 171-token generation, 25-token prompt, q8 KV cache, 200k context, `--temp 0.7`.

### IQ1_M note

The model contains 4 IQ1_M tensors (`blk.0.ffn_up`, `blk.13/14/62.attn_gate`). IQ1_M lacks an MMQ kernel in the CUDA/HIP backend, but this is **not** related to the crash — the `should_use_mmq()` dispatch returns `false` for IQ1_M, and the MMVQ path (`vec_dot_iq1_m_q8_1` in `mmvq.cu`) handles it correctly. The crash is solely from the 0-free-VRAM split bug.