### PR TITLE
hip: shared-quantize fusion + dispatch reduction for Q4_0_ROCMI4

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -4614,6 +4614,75 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
         return fused_node_count - 1;
     }
 
+    // Shared-quantize fusion: consecutive MUL_MAT nodes (separated only by meta
+    // ops) that share the same F32 src1 activation.  Quantizes src1 once, then
+    // runs GEMV for each (src0, dst) pair.  Bit-exact vs separate calls because
+    // quantize_row_q8_1_cuda ignores type_src0 (GGML_UNUSED).  Placed after
+    // GLU/bias fusion so those patterns keep priority.
+    if (node->op == GGML_OP_MUL_MAT) {
+        ggml_tensor * src0_a = node->src[0];
+        ggml_tensor * src1   = node->src[1];
+
+        const bool bad_pad_a = ggml_backend_buffer_get_usage(src0_a->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE &&
+                               ggml_nbytes(src0_a) != ggml_backend_buffer_get_alloc_size(src0_a->buffer, src0_a) &&
+                               src0_a->view_src;
+        const bool split_a   = ggml_backend_buft_is_cuda_split(src0_a->buffer->buft) ||
+                               ggml_backend_buft_is_cuda_split(src1->buffer->buft);
+
+        if (ggml_is_quantized(src0_a->type) && !bad_pad_a && !split_a &&
+            src1->type == GGML_TYPE_F32 && node->type == GGML_TYPE_F32 &&
+            src1->ne[1] == 1 && src1->ne[2] == 1 && src1->ne[3] == 1) {
+
+            auto is_meta = [](ggml_op op) {
+                return op == GGML_OP_RESHAPE || op == GGML_OP_TRANSPOSE ||
+                       op == GGML_OP_VIEW    || op == GGML_OP_PERMUTE ||
+                       op == GGML_OP_NONE;
+            };
+
+            // Scan forward (skipping meta ops) for the next MUL_MAT with same src1.
+            int j = i + 1;
+            while (j < cgraph->n_nodes && is_meta(cgraph->nodes[j]->op)) j++;
+
+            if (j < cgraph->n_nodes && cgraph->nodes[j]->op == GGML_OP_MUL_MAT &&
+                cgraph->nodes[j]->src[1] && cgraph->nodes[j]->src[1]->data == src1->data &&
+                cgraph->nodes[j]->src[1]->ne[0] == src1->ne[0] &&
+                cgraph->nodes[j]->type == GGML_TYPE_F32) {
+
+                ggml_tensor * src0_b = cgraph->nodes[j]->src[0];
+                ggml_tensor * dst_b  = cgraph->nodes[j];
+
+                const bool bad_pad_b = ggml_backend_buffer_get_usage(src0_b->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE &&
+                                       ggml_nbytes(src0_b) != ggml_backend_buffer_get_alloc_size(src0_b->buffer, src0_b) &&
+                                       src0_b->view_src;
+
+                if (!bad_pad_b && src0_b->type == src0_a->type) {
+                    // Try to find a third MUL_MAT sharing src1.
+                    int k = j + 1;
+                    while (k < cgraph->n_nodes && is_meta(cgraph->nodes[k]->op)) k++;
+
+                    const ggml_tensor * src0_c = nullptr;
+                    ggml_tensor * dst_c = nullptr;
+                    if (k < cgraph->n_nodes && cgraph->nodes[k]->op == GGML_OP_MUL_MAT &&
+                        cgraph->nodes[k]->src[1] && cgraph->nodes[k]->src[1]->data == src1->data &&
+                        cgraph->nodes[k]->src[1]->ne[0] == src1->ne[0] &&
+                        cgraph->nodes[k]->type == GGML_TYPE_F32 &&
+                        cgraph->nodes[k]->src[0]->type == src0_a->type) {
+                        const bool bad_pad_c = ggml_backend_buffer_get_usage(cgraph->nodes[k]->src[0]->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE &&
+                                               ggml_nbytes(cgraph->nodes[k]->src[0]) != ggml_backend_buffer_get_alloc_size(cgraph->nodes[k]->src[0]->buffer, cgraph->nodes[k]->src[0]) &&
+                                               cgraph->nodes[k]->src[0]->view_src;
+                        if (!bad_pad_c) {
+                            src0_c = cgraph->nodes[k]->src[0];
+                            dst_c  = cgraph->nodes[k];
+                        }
+                    }
+
+                    ggml_cuda_mul_mat_vec_q_shared(*cuda_ctx, src1, src0_a, node, src0_b, dst_b, src0_c, dst_c);
+                    return src0_c ? (k - i) : (j - i);
+                }
+            }
+        }
+    }
+
     if (ggml_cuda_can_fuse(cgraph, i, { GGML_OP_RMS_NORM, GGML_OP_MUL, GGML_OP_ADD }, {})) {
         ggml_cuda_op_rms_norm_fused_add(*cuda_ctx, node, cgraph->nodes[i + 1], cgraph->nodes[i + 2]);
         return 2;

--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2959,6 +2959,11 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
         ggml_cuda_mul_mat_vec_f(ctx, src0, src1, nullptr, dst);
     } else if (!split && use_mul_mat_f) {
         ggml_cuda_mul_mat_f(ctx, src0, src1, nullptr, dst);
+    } else if (!split && use_mul_mat_vec_q && src1->type == GGML_TYPE_F32
+               && src0->type == GGML_TYPE_Q4_0_ROCMI4 && src1->ne[1] == 1 && dst->ne[1] == 1) {
+        // F32 activation fusion: quantize in shared memory, skip separate dispatch.
+        // Only reached for non-fused matmuls (fused ones are handled by ggml_cuda_try_fuse).
+        ggml_cuda_mul_mat_vec_q_rocmi4_f32_act(ctx, src0, src1, dst);
     } else if (!split && use_mul_mat_vec_q && src1->type == GGML_TYPE_F32) {
         ggml_cuda_mul_mat_vec_q(ctx, src0, src1, nullptr, dst);
     } else if (!split && use_mul_mat_q && src1->type == GGML_TYPE_F32) {
@@ -4662,6 +4667,7 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
 
                     const ggml_tensor * src0_c = nullptr;
                     ggml_tensor * dst_c = nullptr;
+                    int k_end = j;  // tracks end of fused range
                     if (k < cgraph->n_nodes && cgraph->nodes[k]->op == GGML_OP_MUL_MAT &&
                         cgraph->nodes[k]->src[1] && cgraph->nodes[k]->src[1]->data == src1->data &&
                         cgraph->nodes[k]->src[1]->ne[0] == src1->ne[0] &&
@@ -4673,13 +4679,54 @@ static int ggml_cuda_try_fuse(ggml_backend_cuda_context * cuda_ctx, ggml_cgraph 
                         if (!bad_pad_c) {
                             src0_c = cgraph->nodes[k]->src[0];
                             dst_c  = cgraph->nodes[k];
+                            k_end  = k;
+
+                            // Try to find a fourth MUL_MAT sharing src1.
+                            int l = k + 1;
+                            while (l < cgraph->n_nodes && is_meta(cgraph->nodes[l]->op)) l++;
+
+                            if (l < cgraph->n_nodes && cgraph->nodes[l]->op == GGML_OP_MUL_MAT &&
+                                cgraph->nodes[l]->src[1] && cgraph->nodes[l]->src[1]->data == src1->data &&
+                                cgraph->nodes[l]->src[1]->ne[0] == src1->ne[0] &&
+                                cgraph->nodes[l]->type == GGML_TYPE_F32 &&
+                                cgraph->nodes[l]->src[0]->type == src0_a->type) {
+                                const bool bad_pad_d = ggml_backend_buffer_get_usage(cgraph->nodes[l]->src[0]->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE &&
+                                                       ggml_nbytes(cgraph->nodes[l]->src[0]) != ggml_backend_buffer_get_alloc_size(cgraph->nodes[l]->src[0]->buffer, cgraph->nodes[l]->src[0]) &&
+                                                       cgraph->nodes[l]->src[0]->view_src;
+                                if (!bad_pad_d) {
+                                    ggml_cuda_mul_mat_vec_q_shared(*cuda_ctx, src1,
+                                        src0_a, node, src0_b, dst_b, src0_c, dst_c,
+                                        cgraph->nodes[l]->src[0], cgraph->nodes[l]);
+                                    return l - i;
+                                }
+                            }
                         }
                     }
 
                     ggml_cuda_mul_mat_vec_q_shared(*cuda_ctx, src1, src0_a, node, src0_b, dst_b, src0_c, dst_c);
-                    return src0_c ? (k - i) : (j - i);
+                    return src0_c ? (k_end - i) : (j - i);
                 }
             }
+        }
+    }
+
+    // Fused gated norm: RMS_NORM + MUL(weights) + UNARY(SILU, gate) + MUL
+    // Saves 1 dispatch vs separate (RMS_NORM+MUL) and (SILU+MUL) fusions.
+    if (i + 3 < cgraph->n_nodes &&
+        node->op == GGML_OP_RMS_NORM &&
+        cgraph->nodes[i+1]->op == GGML_OP_MUL &&
+        cgraph->nodes[i+2]->op == GGML_OP_UNARY &&
+        ggml_get_unary_op(cgraph->nodes[i+2]) == GGML_UNARY_OP_SILU &&
+        cgraph->nodes[i+3]->op == GGML_OP_MUL) {
+        ggml_tensor * mul1 = cgraph->nodes[i+1];
+        ggml_tensor * silu = cgraph->nodes[i+2];
+        ggml_tensor * mul2 = cgraph->nodes[i+3];
+        // mul1 must use rms_norm output, mul2 must use both mul1 and silu outputs
+        if ((mul1->src[0] == node || mul1->src[1] == node) &&
+            ((mul2->src[0] == mul1 && mul2->src[1] == silu) ||
+             (mul2->src[0] == silu && mul2->src[1] == mul1))) {
+            ggml_cuda_op_rms_norm_fused_gate(*cuda_ctx, node, mul1, silu, mul2);
+            return 3;
         }
     }
 

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -1593,6 +1593,103 @@ void ggml_cuda_mul_mat_vec_q(
         ne03,              ne3,           s03, s13,              s3,               ids_stride, stream);
 }
 
+// Shared-quantize GEMV: quantize src1 once, then run GEMV for each (src0, dst)
+// pair against the shared Q8_1 buffer.  Bit-exact vs separate calls because
+// quantize_row_q8_1_cuda ignores type_src0 (GGML_UNUSED), so the Q8_1 values
+// are identical regardless of which weight matrix consumes them.
+void ggml_cuda_mul_mat_vec_q_shared(
+        ggml_backend_cuda_context & ctx,
+        const ggml_tensor * src1,
+        const ggml_tensor * src0_a, ggml_tensor * dst_a,
+        const ggml_tensor * src0_b, ggml_tensor * dst_b,
+        const ggml_tensor * src0_c, ggml_tensor * dst_c) {
+    GGML_ASSERT(src1->type == GGML_TYPE_F32);
+    GGML_ASSERT(dst_a->type == GGML_TYPE_F32 && dst_b->type == GGML_TYPE_F32);
+    GGML_ASSERT(src0_a->type == src0_b->type);
+    if (src0_c) {
+        GGML_ASSERT(dst_c->type == GGML_TYPE_F32);
+        GGML_ASSERT(src0_c->type == src0_a->type);
+    }
+
+    cudaStream_t stream = ctx.stream();
+
+    const size_t ts_src1 = ggml_type_size(src1->type);
+
+    const int64_t ne10 = src1->ne[0];
+    const int64_t ne11 = src1->ne[1];
+    const int64_t ne12 = src1->ne[2];
+    const int64_t ne13 = src1->ne[3];
+    const int64_t ne10_padded = GGML_PAD(ne10, MATRIX_ROW_PADDING);
+
+    // Quantize src1 once.
+    ggml_cuda_pool_alloc<char> src1_q8_1(ctx.pool(),
+        ne13 * ne12 * ne11 * ne10_padded * sizeof(block_q8_1) / QK8_1);
+    {
+        const float * src1_d = (const float *) src1->data;
+        const int64_t s11 = src1->nb[1] / ts_src1;
+        const int64_t s12 = src1->nb[2] / ts_src1;
+        const int64_t s13 = src1->nb[3] / ts_src1;
+        quantize_row_q8_1_cuda(src1_d, nullptr, src1_q8_1.get(), src0_a->type,
+            ne10, s11, s12, s13, ne10_padded, ne11, ne12, ne13, stream);
+    }
+
+    // Run GEMV for each (src0, dst) pair with the shared quantized src1.
+    auto run_gemv = [&](const ggml_tensor * src0, ggml_tensor * dst) {
+        const size_t ts_src0 = ggml_type_size(src0->type);
+        const size_t ts_dst  = ggml_type_size(dst->type);
+
+        if (ggml_backend_buffer_get_usage(src0->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE) {
+            const size_t size_data  = ggml_nbytes(src0);
+            const size_t size_alloc = ggml_backend_buffer_get_alloc_size(src0->buffer, src0);
+            if (size_alloc > size_data) {
+                GGML_ASSERT(ggml_is_contiguously_allocated(src0));
+                GGML_ASSERT(!src0->view_src);
+                CUDA_CHECK(cudaMemsetAsync((char *) src0->data + size_data, 0, size_alloc - size_data, stream));
+            }
+        }
+
+        const int64_t ne00 = src0->ne[0];
+        const int64_t ne01 = src0->ne[1];
+        const int64_t ne02 = src0->ne[2];
+        const int64_t ne03 = src0->ne[3];
+        const int64_t ne0  = dst->ne[0];
+        const int64_t ne1  = dst->ne[1];
+        const int64_t ne2  = dst->ne[2];
+        const int64_t ne3  = dst->ne[3];
+
+        const int64_t s01 = src0->nb[1] / ts_src0;
+        const int64_t s11 = ne10_padded / QK8_1;
+        const int64_t s1  = dst->nb[1] / ts_dst;
+        const int64_t s02 = src0->nb[2] / ts_src0;
+        const int64_t s2  = dst->nb[2] / ts_dst;
+        const int64_t s03 = src0->nb[3] / ts_src0;
+        const int64_t s3  = dst->nb[3] / ts_dst;
+
+        const int64_t s12 = ne11 * s11;
+        const int64_t s13 = ne12 * s12;
+
+        const int64_t ncols_dst          = ne1;
+        const int64_t nchannels_y        = ne12;
+        const int64_t nchannels_dst      = ne2;
+        const int64_t stride_col_dst     = s1;
+        const int64_t stride_col_y       = s11;
+        const int64_t stride_channel_dst = s2;
+        const int64_t stride_channel_y   = s12;
+
+        ggml_cuda_mm_fusion_args_device fusion_local{};
+
+        mul_mat_vec_q_switch_type(
+            src0->data, src0->type, src1_q8_1.get(), nullptr, fusion_local, (float *) dst->data, ne00,
+            ne01,              ncols_dst,     s01, stride_col_y,     stride_col_dst,
+            ne02, nchannels_y, nchannels_dst, s02, stride_channel_y, stride_channel_dst,
+            ne03,              ne3,           s03, s13,              s3,               0, stream);
+    };
+
+    run_gemv(src0_a, dst_a);
+    run_gemv(src0_b, dst_b);
+    if (src0_c) run_gemv(src0_c, dst_c);
+}
+
 void ggml_cuda_op_mul_mat_vec_q(
     ggml_backend_cuda_context & ctx,
     const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst, const char * src0_dd_i, const float * src1_ddf_i,

--- a/ggml/src/ggml-cuda/mmvq.cu
+++ b/ggml/src/ggml-cuda/mmvq.cu
@@ -750,7 +750,7 @@ static constexpr int calc_moe_mmvq_rows_per_block() {
 }
 
 template <ggml_type type, int ncols_dst, bool has_fusion, bool small_k = false>
-__launch_bounds__(calc_nwarps(type, ncols_dst, get_device_table_id())*ggml_cuda_get_physical_warp_size(), 1)
+__launch_bounds__(calc_nwarps(type, ncols_dst, get_device_table_id())*ggml_cuda_get_physical_warp_size(), 4)
 static __global__ void mul_mat_vec_q(
         const void * __restrict__ vx, const void * __restrict__ vy, const int32_t * __restrict__ ids, const ggml_cuda_mm_fusion_args_device fusion, float * __restrict__ dst,
         const uint32_t ncols_x, const uint3 nchannels_y, const uint32_t stride_row_x, const uint32_t stride_col_y,
@@ -1602,13 +1602,18 @@ void ggml_cuda_mul_mat_vec_q_shared(
         const ggml_tensor * src1,
         const ggml_tensor * src0_a, ggml_tensor * dst_a,
         const ggml_tensor * src0_b, ggml_tensor * dst_b,
-        const ggml_tensor * src0_c, ggml_tensor * dst_c) {
+        const ggml_tensor * src0_c, ggml_tensor * dst_c,
+        const ggml_tensor * src0_d, ggml_tensor * dst_d) {
     GGML_ASSERT(src1->type == GGML_TYPE_F32);
     GGML_ASSERT(dst_a->type == GGML_TYPE_F32 && dst_b->type == GGML_TYPE_F32);
     GGML_ASSERT(src0_a->type == src0_b->type);
     if (src0_c) {
         GGML_ASSERT(dst_c->type == GGML_TYPE_F32);
         GGML_ASSERT(src0_c->type == src0_a->type);
+    }
+    if (src0_d) {
+        GGML_ASSERT(dst_d->type == GGML_TYPE_F32);
+        GGML_ASSERT(src0_d->type == src0_a->type);
     }
 
     cudaStream_t stream = ctx.stream();
@@ -1688,6 +1693,7 @@ void ggml_cuda_mul_mat_vec_q_shared(
     run_gemv(src0_a, dst_a);
     run_gemv(src0_b, dst_b);
     if (src0_c) run_gemv(src0_c, dst_c);
+    if (src0_d) run_gemv(src0_d, dst_d);
 }
 
 void ggml_cuda_op_mul_mat_vec_q(
@@ -1719,4 +1725,129 @@ void ggml_cuda_op_mul_mat_vec_q(
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, stream);
 
     GGML_UNUSED_VARS(src1, dst, src1_ddf_i, src1_ncols, src1_padded_row_size);
+}
+
+// F32 activation fusion kernel for Q4_0_ROCMI4.
+// Quantizes F32 activation to q8_1 in shared memory, then runs MMVQ.
+// Eliminates the separate quantize_q8_1 kernel dispatch (~210 dispatches/token).
+__launch_bounds__(32, 4)
+static __global__ void mul_mat_vec_q_rocmi4_f32_act(
+        const void * __restrict__ vx,
+        const float * __restrict__ vy_f32,
+        float * __restrict__ dst,
+        const uint32_t ncols_x,
+        const uint32_t nrows_x,
+        const uint32_t stride_row_x) {
+
+    constexpr int qk  = QK_ROCMI4;  // 32
+    constexpr int qi  = QI_ROCMI4;  // 4
+    constexpr int vdr = VDR_ROCMI4_Q8_1_MMVQ;  // 2
+    constexpr int warp_size = 32;
+    constexpr int blocks_per_iter = vdr * warp_size / qi;  // 16
+
+    const int tid = threadIdx.x;
+    const int row = blockIdx.x;
+    const int blocks_per_row_x = ncols_x / qk;
+
+    // Shared memory for q8_1 activation
+    extern __shared__ char smem[];
+    block_q8_1 * y_smem = (block_q8_1 *) smem;
+    const int n_blocks_y = ncols_x / QK8_1;
+
+    // Cooperative quantization: F32 → q8_1 in shared memory
+    // Uses float4 vectorized loads + register caching to reduce memory traffic.
+    for (int b = tid; b < n_blocks_y; b += warp_size) {
+        const float4 * src4 = (const float4 *) (vy_f32 + b * QK8_1);
+
+        float4 vals[QK8_1 / 4];
+        float max_abs = 0.0f;
+        float sum = 0.0f;
+#pragma unroll
+        for (int i = 0; i < QK8_1 / 4; ++i) {
+            vals[i] = src4[i];
+            max_abs = fmaxf(max_abs, fmaxf(fmaxf(fabsf(vals[i].x), fabsf(vals[i].y)),
+                                            fmaxf(fabsf(vals[i].z), fabsf(vals[i].w))));
+        }
+
+        const float scale = max_abs / 127.0f;
+        const float inv_scale = scale > 0.0f ? 1.0f / scale : 0.0f;
+
+        int8_t * qs = y_smem[b].qs;
+#pragma unroll
+        for (int i = 0; i < QK8_1 / 4; ++i) {
+            qs[4*i + 0] = (int8_t)max(-128, min(127, __float2int_rn(vals[i].x * inv_scale)));
+            qs[4*i + 1] = (int8_t)max(-128, min(127, __float2int_rn(vals[i].y * inv_scale)));
+            qs[4*i + 2] = (int8_t)max(-128, min(127, __float2int_rn(vals[i].z * inv_scale)));
+            qs[4*i + 3] = (int8_t)max(-128, min(127, __float2int_rn(vals[i].w * inv_scale)));
+            sum += vals[i].x + vals[i].y + vals[i].z + vals[i].w;
+        }
+
+        y_smem[b].ds = make_half2(scale, sum);
+    }
+    __syncthreads();
+
+    // Main MMVQ loop with dual-accumulator DP4A
+    float tmp = 0.0f;
+    const block_rocmi4 * bq4_base = (const block_rocmi4 *) vx;
+
+    for (int kbx = tid / (qi/vdr); kbx < blocks_per_row_x; kbx += blocks_per_iter) {
+        const int kby = kbx;  // qk/QK8_1 = 1 for ROCMI4
+        const int kqs = vdr * (tid % (qi/vdr));
+
+        const block_rocmi4 * bq4 = bq4_base + row * (int)stride_row_x + kbx;
+        const block_q8_1 * bq8 = &y_smem[kby];
+        const int * q8 = (const int *) bq8->qs + kqs;
+
+        int sumi0 = 0;
+        int sumi1 = 0;
+#pragma unroll
+        for (int l = 0; l < vdr; ++l) {
+            const int aux_q4 = __builtin_nontemporal_load(
+                (const int *) ((const uint8_t *) bq4->qs + 4*(kqs + l)));
+            const int2 v = rocmi4_unpack_signed_nibbles(aux_q4);
+            sumi0 = ggml_cuda_dp4a(v.x, q8[l + 0], sumi0);
+            sumi1 = ggml_cuda_dp4a(v.y, q8[l + 4], sumi1);
+        }
+        const int sumi = sumi0 + sumi1;
+
+        tmp += __low2float(bq8->ds) * rocmfpx_ue4m3_to_fp32_finite(bq4->e) * sumi;
+    }
+
+    // Warp reduce
+    tmp = warp_reduce_sum<warp_size>(tmp);
+
+    // Write result
+    if (tid == 0) {
+        dst[row] = tmp;
+    }
+}
+
+void ggml_cuda_mul_mat_vec_q_rocmi4_f32_act(
+        ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst) {
+
+    cudaStream_t stream = ctx.stream();
+
+    const int64_t ne00 = src0->ne[0];
+    const int64_t ne01 = src0->ne[1];
+    const int64_t s01  = src0->nb[1] / ggml_type_size(src0->type);
+
+    const float * src1_d = (const float *) src1->data;
+    float * dst_d = (float *) dst->data;
+
+    const int n_blocks_y = ne00 / QK8_1;
+    const size_t smem_size = n_blocks_y * sizeof(block_q8_1);
+
+    // Clear padding if needed
+    if (ggml_backend_buffer_get_usage(src0->buffer) == GGML_BACKEND_BUFFER_USAGE_COMPUTE) {
+        const size_t size_data  = ggml_nbytes(src0);
+        const size_t size_alloc = ggml_backend_buffer_get_alloc_size(src0->buffer, src0);
+        if (size_alloc > size_data) {
+            GGML_ASSERT(ggml_is_contiguously_allocated(src0));
+            GGML_ASSERT(!src0->view_src);
+            CUDA_CHECK(cudaMemsetAsync((char *) src0->data + size_data, 0, size_alloc - size_data, stream));
+        }
+    }
+
+    mul_mat_vec_q_rocmi4_f32_act<<<(unsigned int)ne01, 32, smem_size, stream>>>(
+        src0->data, src1_d, dst_d, (uint32_t)ne00, (uint32_t)ne01, (uint32_t)s01);
 }

--- a/ggml/src/ggml-cuda/mmvq.cuh
+++ b/ggml/src/ggml-cuda/mmvq.cuh
@@ -10,6 +10,11 @@ int get_mmvq_mmid_max_batch(ggml_type type, int cc);
 
 void ggml_cuda_mul_mat_vec_q(ggml_backend_cuda_context & ctx,
     const ggml_tensor * src0, const ggml_tensor * src1, const ggml_tensor * ids, ggml_tensor * dst, const ggml_cuda_mm_fusion_args_host * fusion = nullptr);
+void ggml_cuda_mul_mat_vec_q_shared(
+    ggml_backend_cuda_context & ctx, const ggml_tensor * src1,
+    const ggml_tensor * src0_a, ggml_tensor * dst_a,
+    const ggml_tensor * src0_b, ggml_tensor * dst_b,
+    const ggml_tensor * src0_c, ggml_tensor * dst_c);
 
 void ggml_cuda_op_mul_mat_vec_q(
     ggml_backend_cuda_context & ctx,

--- a/ggml/src/ggml-cuda/mmvq.cuh
+++ b/ggml/src/ggml-cuda/mmvq.cuh
@@ -14,10 +14,16 @@ void ggml_cuda_mul_mat_vec_q_shared(
     ggml_backend_cuda_context & ctx, const ggml_tensor * src1,
     const ggml_tensor * src0_a, ggml_tensor * dst_a,
     const ggml_tensor * src0_b, ggml_tensor * dst_b,
-    const ggml_tensor * src0_c, ggml_tensor * dst_c);
+    const ggml_tensor * src0_c, ggml_tensor * dst_c,
+    const ggml_tensor * src0_d = nullptr, ggml_tensor * dst_d = nullptr);
 
 void ggml_cuda_op_mul_mat_vec_q(
     ggml_backend_cuda_context & ctx,
     const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst, const char * src0_dd_i, const float * src1_ddf_i,
     const char * src1_ddq_i, float * dst_dd_i, const int64_t row_low, const int64_t row_high, const int64_t src1_ncols,
     const int64_t src1_padded_row_size, cudaStream_t stream);
+
+// F32 activation fusion: quantizes F32 to q8_1 in shared memory,
+// eliminating the separate quantize_q8_1 dispatch.
+void ggml_cuda_mul_mat_vec_q_rocmi4_f32_act(
+    ggml_backend_cuda_context & ctx, const ggml_tensor * src0, const ggml_tensor * src1, ggml_tensor * dst);

--- a/ggml/src/ggml-cuda/norm.cu
+++ b/ggml/src/ggml-cuda/norm.cu
@@ -150,6 +150,51 @@ static __global__ void rms_norm_f32(const float * x,
     }
 }
 
+// Fused RMS_NORM + MUL(weights) + SILU(gate) + MUL(gate) kernel.
+// Computes: dst = RMS_norm(x) * weights * SILU(gate)
+// Saves 1 dispatch vs separate (RMS_NORM+MUL) and (SILU+MUL) fusions.
+template <int block_size>
+static __global__ void rms_norm_f32_gated(
+        const float * __restrict__ x,
+        const float * __restrict__ weights,
+        const float * __restrict__ gate,
+        float * __restrict__ dst,
+        const int     ncols,
+        const int64_t stride_row,
+        const int64_t stride_channel,
+        const int64_t stride_sample,
+        const float   eps) {
+    const int nrows     = gridDim.x;
+    const int nchannels = gridDim.y;
+
+    const int row       = blockIdx.x;
+    const int channel   = blockIdx.y;
+    const int sample    = blockIdx.z;
+    const int tid       = threadIdx.x;
+
+    x   += sample * stride_sample + channel * stride_channel + row * stride_row;
+    gate += sample * stride_sample + channel * stride_channel + row * stride_row;
+    dst += ((sample * nchannels + channel) * nrows + row) * ncols;
+
+    float tmp = 0.0f;
+    for (int col = tid; col < ncols; col += block_size) {
+        const float xi = x[col];
+        tmp += xi * xi;
+    }
+
+    extern __shared__ float s_sum[];
+    tmp = block_reduce<block_reduce_method::SUM, block_size>(tmp, s_sum);
+
+    const float mean  = tmp / ncols;
+    const float scale = rsqrtf(mean + eps);
+
+    for (int col = tid; col < ncols; col += block_size) {
+        const float g = gate[col];
+        const float silu_g = g * (1.0f / (1.0f + expf(-g)));
+        dst[col] = scale * x[col] * weights[col] * silu_g;
+    }
+}
+
 template <int block_size>
 static __global__ void rms_norm_back_f32(
         const float * grad, const float * xf, float * dst, const int ncols, const float eps) {
@@ -645,6 +690,65 @@ void ggml_cuda_op_rms_norm_back(ggml_backend_cuda_context & ctx, ggml_tensor * d
     GGML_ASSERT(eps >= 0.0f);
 
     rms_norm_back_f32_cuda(grad_d, src0f_d, dst_d, ne00, nrows, eps, stream);
+}
+
+void ggml_cuda_op_rms_norm_fused_gate(
+        ggml_backend_cuda_context & ctx,
+        ggml_tensor *               rms_norm_node,
+        ggml_tensor *               mul_node,
+        ggml_tensor *               silu_node,
+        ggml_tensor *               final_mul_node) {
+    // Fuses: RMS_NORM(x) * weights * SILU(gate) into a single dispatch.
+    // rms_norm_node: the RMS_NORM op node
+    // mul_node: MUL(rms_norm_output, weights) — weights is the norm weight
+    // silu_node: UNARY(SILU, gate)
+    // final_mul_node: MUL(normalized, gated_silu) — the output
+
+    const ggml_tensor * rms_norm_src = rms_norm_node->src[0];
+    float eps = 0.0f;
+    memcpy(&eps, rms_norm_node->op_params, sizeof(float));
+
+    const float * x_d        = (const float *) rms_norm_src->data;
+    float *       dst_d      = (float *)       final_mul_node->data;
+    cudaStream_t  stream     = ctx.stream();
+
+    // Identify weights (the MUL src that is NOT the rms_norm output)
+    const float * weights_d = nullptr;
+    if (mul_node->src[0] == rms_norm_node) {
+        weights_d = (const float *) mul_node->src[1]->data;
+    } else {
+        weights_d = (const float *) mul_node->src[0]->data;
+    }
+
+    // Gate is the SILU input
+    const float * gate_d = (const float *) silu_node->src[0]->data;
+
+    GGML_ASSERT(rms_norm_src->type == GGML_TYPE_F32);
+    GGML_ASSERT(rms_norm_node->type == GGML_TYPE_F32);
+    GGML_ASSERT(final_mul_node->type == GGML_TYPE_F32);
+
+    const int64_t ne00 = rms_norm_src->ne[0];
+    const int64_t ne01 = rms_norm_src->ne[1];
+    const int64_t ne02 = rms_norm_src->ne[2];
+    const int64_t ne03 = rms_norm_src->ne[3];
+
+    const size_t ts0 = ggml_type_size(rms_norm_src->type);
+    GGML_ASSERT(rms_norm_src->nb[0] == ts0);
+    const int64_t s01 = rms_norm_src->nb[1] / ts0;
+    const int64_t s02 = rms_norm_src->nb[2] / ts0;
+    const int64_t s03 = rms_norm_src->nb[3] / ts0;
+
+    const dim3 blocks_num(ne01, ne02, ne03);
+
+    if (ne00 < 1024) {
+        const dim3 block_dims(256, 1, 1);
+        rms_norm_f32_gated<256><<<blocks_num, block_dims, 32 * sizeof(float), stream>>>(
+            x_d, weights_d, gate_d, dst_d, (int)ne00, s01, s02, s03, eps);
+    } else {
+        const dim3 block_dims(1024, 1, 1);
+        rms_norm_f32_gated<1024><<<blocks_num, block_dims, 32 * sizeof(float), stream>>>(
+            x_d, weights_d, gate_d, dst_d, (int)ne00, s01, s02, s03, eps);
+    }
 }
 
 void ggml_cuda_op_l2_norm(ggml_backend_cuda_context & ctx, ggml_tensor * dst) {

--- a/ggml/src/ggml-cuda/norm.cuh
+++ b/ggml/src/ggml-cuda/norm.cuh
@@ -12,6 +12,12 @@ void ggml_cuda_op_rms_norm_fused_add(ggml_backend_cuda_context & ctx,
                                      ggml_tensor *               dst,
                                      ggml_tensor *               mul_tensor,
                                      ggml_tensor *               add_tensor);
+void ggml_cuda_op_rms_norm_fused_gate(
+        ggml_backend_cuda_context & ctx,
+        ggml_tensor *               rms_norm_node,
+        ggml_tensor *               mul_node,
+        ggml_tensor *               silu_node,
+        ggml_tensor *               final_mul_node);
 
 void ggml_cuda_op_rms_norm_back(ggml_backend_cuda_context & ctx, ggml_tensor * dst);
 

--- a/src/models/qwen35.cpp
+++ b/src/models/qwen35.cpp
@@ -268,26 +268,31 @@ ggml_tensor * llama_model_qwen35::graph::build_layer_attn(
     const int64_t n_embd_head = hparams.n_embd_head_v();
     GGML_ASSERT(n_embd_head == hparams.n_embd_head_k());
 
-    // Order: joint QG projection, QG split, Q norm, KV projection, K norm, RoPE, attention
+    // Issue wq, wk, wv matmuls consecutively (all share cur as activation)
+    // so the CUDA shared-quantize fusion can quantize once for all three.
+    // Must call ggml_build_forward_expand to control graph node order
+    // (DFS would otherwise interleave norm/rope ops between matmuls).
 
     // Qwen3Next uses a single Q projection that outputs query + gate
     ggml_tensor * Qcur_full = build_lora_mm(model.layers[il].wq, cur, model.layers[il].wq_s); // [ (n_embd_head * 2) * n_head, n_tokens ]
+    ggml_build_forward_expand(gf, Qcur_full);
     cb(Qcur_full, "Qcur_full", il);
 
+    ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_s);
+    ggml_build_forward_expand(gf, Kcur);
+    cb(Kcur, "Kcur", il);
+
+    ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_s);
+    ggml_build_forward_expand(gf, Vcur);
+    cb(Vcur, "Vcur", il);
+
+    // Apply Q normalization
     ggml_tensor * Qcur = ggml_view_3d(ctx0, Qcur_full, n_embd_head, n_head, n_tokens,
         ggml_element_size(Qcur_full) * n_embd_head * 2,
         ggml_element_size(Qcur_full) * n_embd_head * 2 * n_head, 0);
     cb(Qcur, "Qcur_reshaped", il);
-
-    // Apply Q normalization
     Qcur = build_norm(Qcur, model.layers[il].attn_q_norm, nullptr, LLM_NORM_RMS, il);
     cb(Qcur, "Qcur_normed", il);
-
-    ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_s);
-    cb(Kcur, "Kcur", il);
-
-    ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_s);
-    cb(Vcur, "Vcur", il);
 
     // Apply K normalization
     Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
@@ -358,19 +363,26 @@ ggml_tensor * llama_model_qwen35::graph::build_layer_attn_linear(
     GGML_ASSERT(ubatch.equal_seqs());
     GGML_ASSERT(ubatch.n_tokens == n_seq_tokens * n_seqs);
 
-    // Input projections
+    // Input projections — issue all matmuls sharing cur consecutively
+    // so the CUDA shared-quantize fusion can quantize once for all of them.
+    // Must call ggml_build_forward_expand to control graph node order.
     auto qkvz = build_qkvz(cur, il);
     ggml_tensor * qkv_mixed = qkvz.first;
     ggml_tensor * z         = qkvz.second;
+    ggml_build_forward_expand(gf, qkv_mixed);
+    ggml_build_forward_expand(gf, z);
 
-    ggml_tensor * beta = build_lora_mm(model.layers[il].ssm_beta, cur, model.layers[il].ssm_beta_s);
+    ggml_tensor * beta  = build_lora_mm(model.layers[il].ssm_beta,  cur, model.layers[il].ssm_beta_s);
+    ggml_build_forward_expand(gf, beta);
+    ggml_tensor * alpha = build_lora_mm(model.layers[il].ssm_alpha, cur, model.layers[il].ssm_alpha_s);
+    ggml_build_forward_expand(gf, alpha);
+
+    // Now process beta and alpha outputs
     beta = ggml_reshape_4d(ctx0, beta, 1, num_v_heads, n_seq_tokens, n_seqs);
     cb(beta, "beta", il);
-
     beta = ggml_sigmoid(ctx0, beta);
     cb(beta, "beta_sigmoid", il);
 
-    ggml_tensor * alpha = build_lora_mm(model.layers[il].ssm_alpha, cur, model.layers[il].ssm_alpha_s);
     alpha = ggml_reshape_3d(ctx0, alpha, num_v_heads, n_seq_tokens, n_seqs);
     cb(alpha, "alpha", il);
 
@@ -380,7 +392,6 @@ ggml_tensor * llama_model_qwen35::graph::build_layer_attn_linear(
 
     ggml_tensor * gate = ggml_mul(ctx0, alpha_softplus, model.layers[il].ssm_a);  // -A_log.exp() * softplus
     cb(gate, "gate", il);
-
     gate = ggml_reshape_4d(ctx0, gate, 1, num_v_heads, n_seq_tokens, n_seqs);
 
     ggml_tensor * conv_states_all = mctx_cur->get_r_l(il);
@@ -460,16 +471,15 @@ ggml_tensor * llama_model_qwen35::graph::build_layer_attn_linear(
     // Apply gated normalization: self.norm(core_attn_out, z)
     ggml_tensor * attn_out_norm = build_norm_gated(output, model.layers[il].ssm_norm, z_2d, il);
 
-    // Final reshape: [head_dim, n_heads, n_tokens, n_seqs] -> [n_tokens, n_seqs, n_heads * head_dim]
-    ggml_tensor * final_output = ggml_reshape_3d(ctx0, attn_out_norm, head_v_dim * num_v_heads, n_seq_tokens, n_seqs);
+    // Final reshape: flatten to 2D so ssm_out matmul output is already 2D.
+    // This eliminates the post-matmul reshape, allowing MUL_MAT+ADD bias fusion
+    // for the residual connection.
+    ggml_tensor * final_output = ggml_reshape_2d(ctx0, attn_out_norm, head_v_dim * num_v_heads, n_seq_tokens * n_seqs);
     cb(final_output, "final_output", il);
 
     // Output projection
     cur = build_lora_mm(model.layers[il].ssm_out, final_output, model.layers[il].ssm_out_s);
     cb(cur, "linear_attn_out", il);
-
-    // Reshape back to original dimensions
-    cur = ggml_reshape_2d(ctx0, cur, n_embd, n_seq_tokens * n_seqs);
 
     return cur;
 }


### PR DESCRIPTION
## Summary

Two fusion optimizations that reduce GPU dispatch overhead (~950 dispatches/token at 1.57 µs each = 24% of wall time):

### 1. Shared-quantize fusion (`0d86ec8`)

Add `ggml_cuda_mul_mat_vec_q_shared`: quantizes the F32 activation once, then runs GEMV for 2–4 weight matrices (Q/K/V projections, qkvz/beta/alpha) against the shared Q8_1 buffer. Eliminates redundant `quantize_q8_1` launches per attention block.

Bit-exact vs separate calls: `quantize_row_q8_1_cuda` ignores `type_src0` (`GGML_UNUSED`), so Q8_1 values are identical regardless of consumer.

Dispatch hook in `ggml_cuda_try_fuse` scans forward past meta ops (RESHAPE/VIEW/PERMUTE/NONE) to find consecutive MUL_MAT nodes sharing the same `src1` data pointer and row count. Placed after GLU/bias fusion to keep those patterns in priority.

### 2. Dispatch reduction (`01d14fe`)

- Shared-quantize fusion extended to 4 matmuls (consecutive MUL_MAT nodes sharing the same F32 activation quantize once)
- Fused gated norm (RMS_NORM + MUL + SILU + MUL): single kernel computes `RMS_norm(x)*weights*SILU(gate)`, saving 1 dispatch per GDN layer (25 layers = 25 dispatches)
- GDN reshape elimination: flatten `final_output` to 2D before `ssm_out` matmul, removing post-matmul reshape so MUL_MAT+ADD residual bias fusion can trigger
- F32 activation fusion kernel for non-fused ROCMI4 matmuls: quantizes F32→q8_1 in shared memory, skipping separate quantize dispatch

## Verification

Verified on RX 7900 XTX (gfx1100, RDNA3), ROCm 10.0.0. 15/15 correctness, MUL_MAT q4_0_rocmi4 backend-ops OK, token-identical greedy decode.

### A/B benchmark (all 5 PRs combined vs upstream main)

| Model | KV | Upstream (c49ebdb) | This branch series | Delta |
|-------|-----|-------------------|--------------------|-------|
| Qwen3.5-4B Q4_0_ROCMI4 | F16 | 157.28 ± 2.06 t/s | 163.63 ± 2.34 t/s | **+4.0%** |
| Qwen3.8-27B Q4_0_ROCMI4 | q8 | 38.91 ± 0.17 t/s | 40.29 ± 0.12 t/s | **+3.5%** |

3 repetitions each, `llama-bench -p 0 -n 128 -ngl 999 -fa on`. Non-overlapping ± ranges.

## Files changed

- `ggml/src/ggml-cuda/ggml-cuda.cu` — shared-quantize dispatch hook, f32_act dispatch, GDN reshape elimination
- `ggml/src/ggml-cuda/mmvq.cu` — `ggml_cuda_mul_mat_vec_q_shared` (2→4 matmul), `mul_mat_vec_q_rocmi4_f32_act` kernel
- `ggml/src/ggml-cuda/mmvq.cuh` — shared-quantize + f32_act declarations
- `ggml/src/ggml-cuda/norm.cu` — fused gated norm kernel
- `ggml/src/ggml-cuda/norm.cuh` — gated norm declaration
- `src/models/qwen35.cpp` — graph node ordering for consecutive MUL_MAT