### PR TITLE
fix(gemma4-mtp): make separate-model draft-mtp work (5 stacked fixes)

### DIFF
--- a/common/speculative.cpp
+++ b/common/speculative.cpp
@@ -1393,7 +1393,12 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
         auto * ctx_dft = this->params.ctx_dft;
         GGML_ASSERT(ctx_tgt && ctx_dft && "MTP requires ctx_tgt and ctx_dft to be set");
 
-        n_embd = llama_model_n_embd_pre_norm(llama_get_model(ctx_dft));
+        // h rows fed to the draft are the TARGET's pre-norm hidden states.
+        // The draft model's own n_embd_pre_norm (e.g. 1024 for gemma4-assistant)
+        // is NOT the h width: the draft graph's inp_h is n_embd_inp-wide (5376),
+        // so sizing batch.embd by the draft's pre_norm width caused OOB reads
+        // in set_inputs.
+        n_embd = llama_model_n_embd_pre_norm(llama_get_model(ctx_tgt));
         n_mtp_layers = std::max(1, (int) llama_model_n_layer_nextn(llama_get_model(ctx_dft)));
 
         LOG_INF("%s: adding speculative implementation 'draft-mtp'\n", __func__);
@@ -1451,7 +1456,12 @@ struct common_speculative_state_draft_mtp : public common_speculative_impl {
         // Only Gemma4 assistants share the target KV cache. Embedded MTP
         // contexts also use ctx_other to read target hidden states, but keep
         // their own MTP-layer cache and must advance draft positions.
-        is_mem_shared = full_hidden_rows && llama_get_ctx_other(ctx_dft) == ctx_tgt;
+        // A separate-model draft with multiple trained MTP heads must use the
+        // chain_heads mode (one head per draft step, own KV with seq_rm
+        // rollback), even though its context needs ctx_other to read target
+        // hidden states.
+        const bool same_model = llama_get_model(ctx_tgt) == llama_get_model(ctx_dft);
+        is_mem_shared = full_hidden_rows && same_model && llama_get_ctx_other(ctx_dft) == ctx_tgt;
         chain_heads   = n_mtp_layers > 1 && !is_mem_shared;
 
         if (chain_heads) {

--- a/ggml/src/ggml-backend.cpp
+++ b/ggml/src/ggml-backend.cpp
@@ -255,6 +255,13 @@ void ggml_backend_tensor_set_async(ggml_backend_t backend, struct ggml_tensor * 
     GGML_ASSERT(backend);
     GGML_ASSERT(tensor);
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+    if (offset + size > ggml_nbytes(tensor)) {
+        GGML_LOG_ERROR("tensor write OOB: name=%s type=%s ne=[%lld,%lld,%lld,%lld] nbytes=%zu offset=%zu size=%zu\n",
+            tensor->name ? tensor->name : "(null)",
+            ggml_type_name(tensor->type),
+            (long long)tensor->ne[0], (long long)tensor->ne[1], (long long)tensor->ne[2], (long long)tensor->ne[3],
+            ggml_nbytes(tensor), offset, size);
+    }
     GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor write out of bounds");
 
     if (backend->iface.set_tensor_async == NULL) {
@@ -269,6 +276,13 @@ void ggml_backend_tensor_get_async(ggml_backend_t backend, const struct ggml_ten
     GGML_ASSERT(backend);
     GGML_ASSERT(tensor);
     GGML_ASSERT(tensor->data != NULL && "tensor not allocated");
+    if (offset + size > ggml_nbytes(tensor)) {
+        GGML_LOG_ERROR("tensor read OOB: name=%s type=%s ne=[%lld,%lld,%lld,%lld] nbytes=%zu offset=%zu size=%zu\n",
+            tensor->name ? tensor->name : "(null)",
+            ggml_type_name(tensor->type),
+            (long long)tensor->ne[0], (long long)tensor->ne[1], (long long)tensor->ne[2], (long long)tensor->ne[3],
+            ggml_nbytes(tensor), offset, size);
+    }
     GGML_ASSERT(offset + size <= ggml_nbytes(tensor) && "tensor read out of bounds");
 
     if (backend->iface.get_tensor_async == NULL) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1,4 +1,4 @@
-#include "llama-context.h"
+﻿#include "llama-context.h"
 
 #include "ggml.h"
 #include "llama-arch.h"
@@ -239,9 +239,10 @@ llama_context::llama_context(
 
     // With SPLIT_MODE_TENSOR both contexts share meta-backend buffers;
     // a reused graph holds dangling per-device refs after the peer rebuilds.
-    if (cparams.ctx_other != nullptr &&
-        (model.split_mode() == LLAMA_SPLIT_MODE_TENSOR ||
-         cparams.ctx_other->get_model().split_mode() == LLAMA_SPLIT_MODE_TENSOR)) {
+    // Also disable for any ctx_other pair (gemma4 MTP shared-KV): a graph cached
+    // from an empty-batch build (warmup/reserve) keeps ne[1]=0 on h_nextn-style
+    // outputs and later decodes read out of bounds.
+    if (cparams.ctx_other != nullptr) {
         graph_reuse_disable = true;
         cparams.ctx_other->graph_reuse_disable = true;
     }

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -1,4 +1,4 @@
-#include "llama-graph.h"
+﻿#include "llama-graph.h"
 
 #include "llama-impl.h"
 #include "llama-model.h"
@@ -130,7 +130,7 @@ void llm_graph_input_embd_h::set_input(const llama_ubatch * ubatch) {
         GGML_ASSERT(ubatch->embd);
         GGML_ASSERT(n_embd == embd->ne[0]);
 
-        ggml_backend_tensor_set(embd, ubatch->embd, 0, n_tokens*n_embd*ggml_element_size(h));
+        ggml_backend_tensor_set(embd, ubatch->embd, 0, n_tokens*n_embd*ggml_element_size(embd));
     }
 
     if (ubatch->embd) {
@@ -1002,6 +1002,7 @@ void llm_graph_result::reset() {
     t_logits      = nullptr;
     t_embd        = nullptr;
     t_embd_pooled = nullptr;
+    t_h_pre_norm  = nullptr; // PR #89: stale pointer caused use-after-free on rebuild
 
     t_layer_inp.resize(LLAMA_MAX_LAYERS + 1);
     std::fill(t_layer_inp.begin(), t_layer_inp.end(), nullptr);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1630,7 +1630,17 @@ const float * llama_model::tensor_split() const {
 }
 
 uint32_t llama_model::n_embd_pre_norm() const {
-    return arch == LLM_ARCH_DEEPSEEK4 ? hparams.n_embd * hparams.n_hc : hparams.n_embd;
+    if (arch == LLM_ARCH_DEEPSEEK4) {
+        return hparams.n_embd * hparams.n_hc;
+    }
+    // gemma4-assistant (MTP draft): the h rows it consumes/produces (inp_h,
+    // h_nextn) are backbone-wide (n_embd_inp, e.g. 5376), NOT its internal
+    // n_embd (1024). decode()'s ubatch embd sizing and the pre-norm extraction
+    // must use the backbone width or set_inputs reads past the ubatch buffer.
+    if (arch == LLM_ARCH_GEMMA4_ASSISTANT) {
+        return hparams.n_embd_inp();
+    }
+    return hparams.n_embd;
 }
 
 uint32_t llama_model::n_gpu_layers() const {

--- a/src/models/gemma4-assistant.cpp
+++ b/src/models/gemma4-assistant.cpp
@@ -134,6 +134,7 @@ llama_model_gemma4_assistant::graph::graph(const llama_model & model, const llm_
     ggml_tensor * inp_out_ids = build_inp_out_ids();
 
     ggml_tensor * inpL = cur;
+    ggml_tensor * inpL_full = nullptr;
 
     for (int il = 0; il < n_layer; ++il) {
         const bool is_swa = hparams.is_swa(il);
@@ -163,6 +164,10 @@ llama_model_gemma4_assistant::graph::graph(const llama_model & model, const llm_
                 Qcur, nullptr, nullptr, nullptr, hparams.f_attention_scale, il, il_src);
 
         if (il == n_layer - 1 && inp_out_ids) {
+            // keep the full-row (all ubatch tokens) residual for the MTP hidden
+            // state: t_h_pre_norm is extracted for all n_tokens, but inp_out_ids
+            // can select zero rows on draft decodes that request no logits
+            inpL_full = inpL;
             cur  = ggml_get_rows(ctx0, cur,  inp_out_ids);
             inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
         }
@@ -202,7 +207,11 @@ llama_model_gemma4_assistant::graph::graph(const llama_model & model, const llm_
     cb(logits, "result_output", -1);
     res->t_logits = logits;
 
-    ggml_tensor * h_next = ggml_mul_mat(ctx0, model.nextn_proj_post, cur);
+    // full-row (all ubatch tokens) source for the MTP hidden state, kept
+    // pre-get_rows; normalized like the original draft path
+    ggml_tensor * h_next_src = inpL_full ? inpL_full : inpL;
+    ggml_tensor * h_next_norm = build_norm(h_next_src, model.output_norm, nullptr, LLM_NORM_RMS, -1);
+    ggml_tensor * h_next = ggml_mul_mat(ctx0, model.nextn_proj_post, h_next_norm);
     cb(h_next, "h_nextn", -1);
     res->t_h_pre_norm = h_next;
 

--- a/tools/server/server-context.cpp
+++ b/tools/server/server-context.cpp
@@ -11,6 +11,7 @@
 #include "diffusion.h"
 #include "llama.h"
 #include "../../src/llama-ext.h"
+#include "../../src/llama-model.h"
 #include "log.h"
 #include "sampling.h"
 #include "speculative.h"
@@ -917,6 +918,12 @@ private:
                 // ctor mis-detect is_mem_shared (gemma4-style shared KV) and disable
                 // chain_heads for multi-head Step MTP3 drafts, breaking draft KV resets.
                 cparams.ctx_type = LLAMA_CONTEXT_TYPE_MTP;
+                if (model_dft->arch == LLM_ARCH_GEMMA4_ASSISTANT) {
+                    // gemma4 MTP draft (GEMMA4_ASSISTANT) requires the target context:
+                    // its ctor throws without ctx_other and it reserves memory against
+                    // the target's hidden states.
+                    cparams.ctx_other = ctx_tgt;
+                }
             } else if (spec_eagle3 || spec_dflash || spec_dspark) {
                 cparams.ctx_other = ctx_tgt;
             }


### PR DESCRIPTION
﻿Fixes #108 (5 stacked bugs in the separate-model `draft-mtp` path for Gemma 4 on Windows/gfx1151; last commit of the ladder is the root cause вЂ” a 1024-vs-5376 h-row width mismatch).

## What

One commit, 7 files, all changes scoped to the gemma4 MTP path:

1. **`tools/server/server-context.cpp`** вЂ” pass `ctx_other = ctx_tgt` when the draft model arch is `LLAMA_ARCH_GEMMA4_ASSISTANT`. Without it the draft context ctor throws `Gemma4Assistant requires ctx_other to be set` and `llama-server`/`llama-cli` abort at load. (The existing NOTE about not setting `ctx_other` for separate-model MTP drafts concerns `is_mem_shared` detection, which is now guarded separately вЂ” see 3.)

2. **`src/models/gemma4-assistant.cpp`** вЂ” keep the full-row residual (`inpL_full`, before the last-layer `ggml_get_rows(inp_out_ids)`) as the source for `h_next`. Draft decodes request no logits, so `inp_out_ids` selects zero rows and `t_h_pre_norm` came out `[n_embd, 0]`; the extraction path then read `n_tokens Г— n_embd` floats out of it:
   `tensor read OOB: name=h_nextn ne=[5376,0,1,1] nbytes=0 ... size=57344`.

3. **`common/speculative.cpp`** вЂ” `is_mem_shared` now additionally requires `llama_get_model(ctx_tgt) == llama_get_model(ctx_dft)`. A **separate-model** multi-head draft (n_mtp_layers=4) must run the `chain_heads` path (one head per step, own KV + `seq_rm` rollback); treating it as shared-KV issued all draft tokens at the same position and later failed with `sequence positions ... Y = X + 1` (memory=17, batch=14). Also: the MTP driver's `n_embd` (h-row width for `batch.embd`) is taken from the **target**'s pre-norm width instead of the draft's internal `n_embd` (1024 vs 5376 вЂ” see 5).

4. **`src/llama-graph.cpp` / `src/llama-context.cpp`** вЂ” `llm_graph_result::reset()` also resets `t_h_pre_norm` (same one-liner as PR #89, credit @serrynaimo) plus graph reuse is disabled for `ctx_other` pairs; both eliminate nondeterministic use-after-free AVs after graph rebuilds.

5. **`src/llama-model.cpp`** вЂ” `llama_model::n_embd_pre_norm()` returns `hparams.n_embd_inp()` (backbone width, 5376) for `LLAMA_ARCH_GEMMA4_ASSISTANT`. Previously it returned `hparams.n_embd` = 1024 (the MTP-layer-internal width), so `llama_context::decode()` sized the ubatch embd buffer as `n_tokens Г— 1024` floats while `set_input()` read `n_tokens Г— 5376` from it вЂ” a host OOB read that showed up as access violations in `ggml_backend_tensor_set` (crash side verified in WinDbg: source pointer unmapped).

## Verification

Windows 11, Ryzen AI MAX+ 395 / 8060S (gfx1151), HIP SDK 7.2, model [kingjones777/Gemma-4-31B-it-ROCmFP4-GGUF](https://huggingface.co/kingjones777/Gemma-4-31B-it-ROCmFP4-GGUF) (`Q4_0_ROCMFP4_COHERENT` + `mtp-gemma-4-31B-it-Q8_0.gguf`), card-model command line (`-c 4096`, `--spec-draft-n-max 5`):

- 2+ full `llama-cli` runs, 100 tokens each: **21.8 / 22.8 / 25.7 tok/s**, coherent text, clean exit (no AV, no asserts).
- `llama-server` on `:1234`: OpenAI-compat chat + **tool-calling verified** (correct JSON function calls), sustained generation ~22 tok/s.
- Baseline without the draft: ~11 tok/s в†’ **~2Г— speedup**, matching the model card's numbers.
- Non-MTP paths unchanged (`Q4_0_ROCMFP4` without `--spec-*` still runs at ~11 tok/s; all five changes are gated on the gemma4-assistant/MTP paths).

